### PR TITLE
kfence: initial allocation hookup prototype

### DIFF
--- a/include/linux/kfence.h
+++ b/include/linux/kfence.h
@@ -1,0 +1,28 @@
+// KFENCE api
+
+#ifdef CONFIG_KFENCE
+void kfence_init(void);
+void *kfence_alloc_and_fix_freelist(struct kmem_cache *s);
+bool kfence_free(struct kmem_cache *s, struct page *page,
+		 void *head, void *tail, int cnt,
+		 unsigned long addr);
+size_t kfence_ksize(void *object);
+
+#else
+static void kfence_init(void) {}
+static void *kfence_alloc_and_fix_freelist(struct kmem_cache *s)
+{
+	return NULL;
+}
+static bool kfence_free(struct kmem_cache *s, struct page *page,
+		 void *head, void *tail, int cnt,
+		 unsigned long addr)
+{
+	return false;
+}
+
+static size_t kfence_ksize(void *object)
+{
+	return 0;
+}
+#endif

--- a/include/linux/slab.h
+++ b/include/linux/slab.h
@@ -112,6 +112,13 @@
 #define SLAB_KASAN		0
 #endif
 
+#ifdef CONFIG_KFENCE
+#ifdef CONFIG_KASAN
+#error Conflicting definitions
+#endif
+#define SLAB_KFENCE		((slab_flags_t __force)0x08000000U)
+#endif
+
 /* The following flags affect the page allocator grouping pages by mobility */
 /* Objects are reclaimable */
 #define SLAB_RECLAIM_ACCOUNT	((slab_flags_t __force)0x00020000U)

--- a/init/main.c
+++ b/init/main.c
@@ -39,6 +39,7 @@
 #include <linux/security.h>
 #include <linux/smp.h>
 #include <linux/profile.h>
+#include <linux/kfence.h>
 #include <linux/rcupdate.h>
 #include <linux/moduleparam.h>
 #include <linux/kallsyms.h>
@@ -892,6 +893,7 @@ asmlinkage __visible void __init start_kernel(void)
 	hrtimers_init();
 	softirq_init();
 	timekeeping_init();
+	kfence_init();
 
 	/*
 	 * For best initial stack canary entropy, prepare it after:

--- a/mm/Kconfig.debug
+++ b/mm/Kconfig.debug
@@ -138,3 +138,9 @@ config PTDUMP_DEBUGFS
 	  kernel.
 
 	  If in doubt, say N.
+
+config KFENCE
+	bool "KFence"
+	#depends on DEBUG_KERNEL
+	---help---
+	  Nothing here

--- a/mm/Makefile
+++ b/mm/Makefile
@@ -110,3 +110,4 @@ obj-$(CONFIG_HMM_MIRROR) += hmm.o
 obj-$(CONFIG_MEMFD_CREATE) += memfd.o
 obj-$(CONFIG_MAPPING_DIRTY_HELPERS) += mapping_dirty_helpers.o
 obj-$(CONFIG_PTDUMP_CORE) += ptdump.o
+obj-$(CONFIG_KFENCE) += kfence.o

--- a/mm/huge_memory.c
+++ b/mm/huge_memory.c
@@ -2705,6 +2705,7 @@ bool can_split_huge_page(struct page *page, int *pextra_pins)
  */
 int split_huge_page_to_list(struct page *page, struct list_head *list)
 {
+	pr_err("HERE: %s:%d, page: %px(%px)\n", __FILE__, __LINE__, page, page_address(page));
 	struct page *head = compound_head(page);
 	struct pglist_data *pgdata = NODE_DATA(page_to_nid(head));
 	struct deferred_split *ds_queue = get_deferred_split_queue(head);

--- a/mm/kfence.c
+++ b/mm/kfence.c
@@ -1,0 +1,265 @@
+/* KFENCE implementation */
+
+#include <asm/pgtable.h>
+#include <asm/tlbflush.h>
+
+#include <linux/mm.h>  // required by slub_def.h, should be included there.
+#include <linux/slab.h>
+#include <linux/slub_def.h>
+#include <linux/spinlock_types.h>
+#include <linux/timer.h>
+
+
+static void kfence_heartbeat(struct timer_list *timer);
+static DEFINE_TIMER(kfence_timer, kfence_heartbeat);
+
+DEFINE_PER_CPU(void *, stored_freelist);
+DEFINE_PER_CPU(struct kmem_cache *, stored_cache);
+struct kmem_cache kfence_slab_cache;
+EXPORT_SYMBOL(kfence_slab_cache);
+
+static DEFINE_SPINLOCK(kfence_lock);
+static DEFINE_SPINLOCK(kfence_alloc_lock);
+
+struct kfence_freelist_t {
+	struct list_head list;
+	void *obj;
+};
+
+/*
+ * It's handy (but not strictly required) that 255 objects with redzones occupy
+ * exactly 2Mb.
+ */
+#define KFENCE_NUM_OBJ_LOG 8
+#define KFENCE_NUM_OBJ ((1 << KFENCE_NUM_OBJ_LOG) - 1)
+
+#define KFENCE_SAMPLING_MS 113
+
+struct kfence_freelist_t *kfence_comb;
+struct list_head kfence_freelist_old;
+struct kfence_freelist_t kfence_freelist, kfence_recycle;
+
+/* TODO(glider): kernel_physical_mapping_change() is x86-only */
+unsigned long kernel_physical_mapping_change(unsigned long start,
+					     unsigned long end,
+					     unsigned long page_size_mask);
+
+/* TODO: need to separate away code that splits physical mappings. */
+void __meminit kfence_protect(unsigned long addr)
+{
+	unsigned long addr_end;
+        pte_t *pte;
+        unsigned int level;
+	int res;
+	unsigned long psize, pmask;
+	int split_page_size_mask;
+
+	addr_end = addr + PAGE_SIZE;
+        pte = lookup_address(addr, &level);
+        BUG_ON(!pte);
+	if (level != PG_LEVEL_4K) {
+		psize = page_level_size(level);
+		pmask = page_level_mask(level);
+		split_page_size_mask = 1 << PG_LEVEL_4K;
+		kernel_physical_mapping_change(__pa(addr & pmask),
+			__pa((addr_end & pmask) + psize),
+			split_page_size_mask);
+		flush_tlb_all();
+		pte = lookup_address(addr, &level);
+	}
+        BUG_ON(level != PG_LEVEL_4K);
+	set_pte(pte, __pte(pte_val(*pte) & ~_PAGE_PRESENT));
+        __flush_tlb_one_kernel(addr);
+}
+
+/* TODO: comb is a poor analogy, come up with a better term. */
+void allocate_comb(void)
+{
+	struct page *pages;
+	struct kfence_freelist_t *objects;
+	char *addr;
+	int i;
+
+	pages = alloc_pages(GFP_KERNEL, KFENCE_NUM_OBJ_LOG + 1);
+	pr_info("kfence allocated pages: %px--%px\n", addr,
+		addr + (KFENCE_NUM_OBJ + 1) * 2 * PAGE_SIZE);
+	/*
+	 * Set up non-redzone pages: they must have PG_slab flag and point to
+	 * kfence slab cache.
+	 */
+	for (i = 0; i < (2 << KFENCE_NUM_OBJ_LOG); i++) {
+		if (i && !(i % 2)) {
+			__SetPageSlab(&pages[i]);
+			pages[i].slab_cache = &kfence_slab_cache;
+		}
+	}
+	addr = page_address(pages);
+	addr += PAGE_SIZE;  // skip the first page: metadata
+	kfence_protect(addr); // first redzone
+	addr += PAGE_SIZE;
+	objects = (struct kfence_freelist_t *)kmalloc_array(KFENCE_NUM_OBJ,
+			sizeof(struct kfence_freelist_t), GFP_KERNEL);
+	for (i = 0; i < KFENCE_NUM_OBJ; i++) {
+		if (i == KFENCE_NUM_OBJ)
+			objects[i].list.next = NULL;
+		else
+			objects[i].list.next = &(objects[i + 1].list);
+		objects[i].obj = addr;
+		kfence_protect(addr + PAGE_SIZE);  // redzone
+		addr += 2 * PAGE_SIZE;
+	}
+	kfence_freelist.list.next = (void *)(&objects[0].list);
+	kfence_freelist.list.prev = (void *)(&objects[KFENCE_NUM_OBJ].list);
+	kfence_comb = objects;
+}
+
+void *guarded_alloc(size_t size)
+{
+	unsigned long flags;
+	void *obj = NULL, *ret;
+	struct kfence_freelist_t *item;
+
+	BUG_ON(size > PAGE_SIZE);
+	spin_lock_irqsave(&kfence_alloc_lock, flags);
+
+	if (!list_empty(&kfence_freelist.list)) {
+		item = list_entry(kfence_freelist.list.next,
+				  struct kfence_freelist_t, list);
+		obj = item->obj;
+		kfence_freelist.list.next = item->list.next;
+		list_add(&(item->list), &kfence_recycle.list);
+	}
+
+	spin_unlock_irqrestore(&kfence_alloc_lock, flags);
+	if (obj)
+		ret = (void *)((char*)obj + PAGE_SIZE - size);
+	else
+		ret = NULL;
+	pr_info("guarded_alloc(%d) returns %px\n", size, ret);
+	return ret;
+}
+
+void guarded_free(void *addr)
+{
+	unsigned long flags;
+	void *aligned_addr = ALIGN_DOWN((unsigned long)addr, PAGE_SIZE);
+	struct kfence_freelist_t *item;
+
+	spin_lock_irqsave(&kfence_alloc_lock, flags);
+	item = list_entry(kfence_recycle.list.next, struct kfence_freelist_t,
+			  list);
+	item->obj = aligned_addr;
+	kfence_recycle.list.next = item->list.next;
+	list_add(&(item->list), &kfence_freelist.list);
+	spin_unlock_irqrestore(&kfence_alloc_lock, flags);
+}
+
+void *kfence_alloc_and_fix_freelist(struct kmem_cache *s)
+{
+	unsigned long flags;
+	struct kmem_cache_cpu *c = raw_cpu_ptr(s->cpu_slab);
+	struct kmem_cache *stored = this_cpu_read(stored_cache);
+	void *ret = NULL;
+	struct page *page;
+
+	if (stored && (s == stored)) {
+		spin_lock_irqsave(&kfence_lock, flags);
+		stored = this_cpu_read(stored_cache);
+		if (stored && (s == stored)) {
+			ret = guarded_alloc(s->size);
+			c->freelist = this_cpu_read(stored_freelist);
+			this_cpu_write(stored_freelist, NULL);
+			this_cpu_write(stored_cache, NULL);
+			page = virt_to_page(ret);
+		}
+		spin_unlock_irqrestore(&kfence_lock, flags);
+		pr_info("kfence_alloc_and_fix_freelist returns %px\n", ret);
+		return ret;
+	}
+	return NULL;
+}
+
+bool kfence_free(struct kmem_cache *s, struct page *page,
+		 void *head, void *tail, int cnt,
+		 unsigned long addr)
+{
+	void *aligned_head = ALIGN_DOWN((unsigned long)head, PAGE_SIZE);
+
+	if (s != &kfence_slab_cache)
+		return false;
+	BUG_ON(head != tail);
+	pr_info("kfence_free(%px)\n", head);
+	BUG_ON(aligned_head != page_address(page));
+	guarded_free(head);
+	return true;
+}
+
+size_t kfence_ksize(void *object)
+{
+	char *upper = ALIGN((unsigned long)object, PAGE_SIZE);
+	return upper - (char *)object;
+}
+
+static void steal_freelist_locked(void)
+{
+	struct kmem_cache_cpu *c;
+	struct kmem_cache *cache;
+	unsigned long int index;
+
+	/* TODO: need a random number here. */
+	index = (jiffies / 13) % (KMALLOC_SHIFT_HIGH - 2 - KMALLOC_SHIFT_LOW)
+		+ KMALLOC_SHIFT_LOW;
+
+	cache = kmalloc_caches[0][index];
+	if (!cache) {
+		pr_info("kmalloc_caches[0][%ld] is NULL!\n", index);
+		BUG_ON(!cache);
+	}
+	c = raw_cpu_ptr(cache->cpu_slab);
+	BUG_ON(!c);
+	this_cpu_write(stored_freelist, c->freelist);
+	this_cpu_write(stored_cache, cache);
+	/* TODO: should locking/atomics be involved? */
+	c->freelist = 0;
+	pr_info("stole freelist from cache %s on CPU%d!\n", cache->name,
+		smp_processor_id());
+}
+
+static void kfence_arm_heartbeat(struct timer_list *timer)
+{
+	unsigned long delay = msecs_to_jiffies(KFENCE_SAMPLING_MS);
+
+	mod_timer(timer, jiffies + delay);
+}
+
+static void kfence_heartbeat(struct timer_list *timer)
+{
+	unsigned long flags;
+
+	if (!this_cpu_read(stored_freelist)) {
+		spin_lock_irqsave(&kfence_lock, flags);
+		if (!this_cpu_read(stored_freelist))
+			steal_freelist_locked();
+		spin_unlock_irqrestore(&kfence_lock, flags);
+	}
+	kfence_arm_heartbeat(timer);
+}
+
+/* TODO: make this function part of SLAB API. */
+int alloc_kmem_cache_cpus(struct kmem_cache *s);
+
+void __init kfence_init(void)
+{
+	spin_lock_init(&kfence_lock);
+	spin_lock_init(&kfence_alloc_lock);
+	INIT_LIST_HEAD(&kfence_freelist.list);
+	INIT_LIST_HEAD(&kfence_recycle.list);
+	memset(&kfence_slab_cache, 0, sizeof(struct kmem_cache));
+	kfence_slab_cache.name = "kfence_slab_cache";
+	alloc_kmem_cache_cpus(&kfence_slab_cache);
+	kfence_slab_cache.flags = SLAB_KFENCE;
+	allocate_comb();
+	kfence_arm_heartbeat(&kfence_timer);
+	pr_info("kfence_init done\n");
+}
+EXPORT_SYMBOL(kfence_init);


### PR DESCRIPTION
No error checking for now, we just steal the freelist from a random
kmalloc cache from time to time, and route SLUB's slow path into our
allocator that returns pages.

Signed-off-by: Alexander Potapenko <glider@google.com>