### PR TITLE
kfence: Various cleanups

### DIFF
--- a/include/linux/kfence.h
+++ b/include/linux/kfence.h
@@ -1,26 +1,36 @@
 // KFENCE api
 
+#include <linux/types.h>
+
+struct kmem_cache;
+struct page;
+
 #ifdef CONFIG_KFENCE
+/* TODO: API documentation */
+
 void kfence_init(void);
+
 void *kfence_alloc_and_fix_freelist(struct kmem_cache *s);
-bool kfence_free(struct kmem_cache *s, struct page *page,
-		 void *head, void *tail, int cnt,
-		 unsigned long addr);
+
+bool kfence_free(struct kmem_cache *s, struct page *page, void *head,
+		 void *tail, int cnt, unsigned long addr);
+
 size_t kfence_ksize(void *object);
 
 #else
-static void kfence_init(void) {}
-static void *kfence_alloc_and_fix_freelist(struct kmem_cache *s)
+static inline void kfence_init(void)
+{
+}
+static inline void *kfence_alloc_and_fix_freelist(struct kmem_cache *s)
 {
 	return NULL;
 }
-static bool kfence_free(struct kmem_cache *s, struct page *page,
-		 void *head, void *tail, int cnt,
-		 unsigned long addr)
+static inline bool kfence_free(struct kmem_cache *s, struct page *page,
+			       void *head, void *tail, int cnt,
+			       unsigned long addr)
 {
 	return false;
 }
-
 static size_t kfence_ksize(void *object)
 {
 	return 0;


### PR DESCRIPTION
* Add missing 'inline' in header.
* Add missing declarations in header.
* Add some TODOs.
* clang-format.

Signed-off-by: Marco Elver <elver@google.com>