### PR TITLE
Get rid of kfence_slab_cache

### DIFF
--- a/include/linux/kfence.h
+++ b/include/linux/kfence.h
@@ -27,6 +27,8 @@ bool kfence_handle_page_fault(unsigned long address);
 
 bool is_kfence_ptr(unsigned long address);
 
+void kfence_observe_memcg_cache(struct kmem_cache *memcg_cache);
+
 #else /* CONFIG_KFENCE */
 
 // TODO: remove for v1
@@ -42,6 +44,7 @@ static inline void kfence_cache_unregister(struct kmem_cache *s) { }
 static inline bool kfence_discard_slab(struct kmem_cache *s, struct page *page) { return false; }
 static inline bool kfence_handle_page_fault(unsigned long address) { return false; }
 static inline bool is_kfence_ptr(unsigned long address) { return false; }
+static inline void kfence_observe_memcg_cache(struct kmem_cache *memcg_cache) { }
 
 // TODO: remove for v1
 // clang-format on

--- a/include/linux/kfence.h
+++ b/include/linux/kfence.h
@@ -23,9 +23,9 @@ void kfence_cache_unregister(struct kmem_cache *s);
 
 bool kfence_discard_slab(struct kmem_cache *s, struct page *page);
 
-bool kfence_handle_page_fault(unsigned long address);
+bool kfence_handle_page_fault(unsigned long addr);
 
-bool is_kfence_ptr(unsigned long address);
+bool is_kfence_addr(unsigned long addr);
 
 void kfence_observe_memcg_cache(struct kmem_cache *memcg_cache);
 
@@ -42,8 +42,8 @@ static inline bool kfence_free(struct kmem_cache *s, struct page *page,
 static inline void kfence_cache_register(struct kmem_cache *s)   { }
 static inline void kfence_cache_unregister(struct kmem_cache *s) { }
 static inline bool kfence_discard_slab(struct kmem_cache *s, struct page *page) { return false; }
-static inline bool kfence_handle_page_fault(unsigned long address) { return false; }
-static inline bool is_kfence_ptr(unsigned long address) { return false; }
+static inline bool kfence_handle_page_fault(unsigned long addr) { return false; }
+static inline bool is_kfence_addr(unsigned long addr) { return false; }
 static inline void kfence_observe_memcg_cache(struct kmem_cache *memcg_cache) { }
 
 // TODO: remove for v1

--- a/include/linux/kfence.h
+++ b/include/linux/kfence.h
@@ -27,6 +27,8 @@ size_t kfence_ksize(const void *object);
 
 bool kfence_handle_page_fault(unsigned long address);
 
+bool is_kfence_ptr(unsigned long address);
+
 #else /* CONFIG_KFENCE */
 
 // TODO: remove for v1
@@ -42,6 +44,7 @@ static inline void kfence_cache_unregister(struct kmem_cache *s) { }
 static inline bool kfence_discard_slab(struct kmem_cache *s, struct page *page) { return false; }
 static inline size_t kfence_ksize(const void *object) { return 0; }
 static inline bool kfence_handle_page_fault(unsigned long address) { return false; }
+static inline bool is_kfence_ptr(unsigned long address) { return false; }
 
 // TODO: remove for v1
 // clang-format on

--- a/include/linux/kfence.h
+++ b/include/linux/kfence.h
@@ -23,8 +23,6 @@ void kfence_cache_unregister(struct kmem_cache *s);
 
 bool kfence_discard_slab(struct kmem_cache *s, struct page *page);
 
-size_t kfence_ksize(const void *object);
-
 bool kfence_handle_page_fault(unsigned long address);
 
 bool is_kfence_ptr(unsigned long address);
@@ -42,7 +40,6 @@ static inline bool kfence_free(struct kmem_cache *s, struct page *page,
 static inline void kfence_cache_register(struct kmem_cache *s)   { }
 static inline void kfence_cache_unregister(struct kmem_cache *s) { }
 static inline bool kfence_discard_slab(struct kmem_cache *s, struct page *page) { return false; }
-static inline size_t kfence_ksize(const void *object) { return 0; }
 static inline bool kfence_handle_page_fault(unsigned long address) { return false; }
 static inline bool is_kfence_ptr(unsigned long address) { return false; }
 

--- a/include/linux/slab.h
+++ b/include/linux/slab.h
@@ -112,13 +112,6 @@
 #define SLAB_KASAN		0
 #endif
 
-#ifdef CONFIG_KFENCE
-/* Reuse same value as KASAN (KFence and KASAN cannot be enabled together). */
-#define SLAB_KFENCE		((slab_flags_t __force)0x08000000U)
-#else
-#define SLAB_KFENCE		0
-#endif
-
 /* The following flags affect the page allocator grouping pages by mobility */
 /* Objects are reclaimable */
 #define SLAB_RECLAIM_ACCOUNT	((slab_flags_t __force)0x00020000U)

--- a/lib/test_kfence.c
+++ b/lib/test_kfence.c
@@ -70,7 +70,7 @@ static void *alloc_from_kfence(size_t size, gfp_t gfp, const char *caller)
 			res = kmalloc(size, gfp);
 		else
 			res = kmem_cache_alloc(current_cache, gfp);
-		if (is_kfence_ptr((unsigned long)res))
+		if (is_kfence_addr((unsigned long)res))
 			return res;
 		free_to_kfence(res);
 		/* TODO: sleep time depends on heartbeat period. */

--- a/lib/test_kfence.c
+++ b/lib/test_kfence.c
@@ -90,7 +90,7 @@ static int do_test_shrink(int size)
 	 * work.
 	 */
 	c = kmem_cache_create("test_cache", size, 1, SLAB_NOLEAKTRACE, NULL);
-	buffer = alloc_from_kfence(NULL, size, GFP_KERNEL, __func__);
+	buffer = alloc_from_kfence(c, size, GFP_KERNEL, __func__);
 	if (!buffer)
 		return 1;
 	kmem_cache_shrink(c);

--- a/lib/test_kfence.c
+++ b/lib/test_kfence.c
@@ -10,7 +10,11 @@
 #include <linux/mm.h>
 #include <linux/module.h>
 #include <linux/slab.h>
-#include <linux/slab_def.h>
+/*
+ * For struct kmem_cache. We cannot include <linux/sl[au]b_def.h>, because it
+ * does not define struct memcg_cache_params used by kmem_cache.
+ */
+#include "../mm/slab.h"
 
 /*
  * TODO: the more caches we support, the fewer is the probability of allocating

--- a/lib/test_kfence.c
+++ b/lib/test_kfence.c
@@ -23,7 +23,8 @@
  * Allocate using either kmalloc or the given memory cache till we get an object
  * from KFENCE pool or hit the maximum number of attempts.
  */
-static void *alloc_from_kfence(struct kmem_cache *s, size_t size, gfp_t gfp, const char *caller)
+static void *alloc_from_kfence(struct kmem_cache *s, size_t size, gfp_t gfp,
+			       const char *caller)
 {
 	void *res;
 	int i;

--- a/lib/test_kfence.c
+++ b/lib/test_kfence.c
@@ -23,27 +23,56 @@
  */
 #define MAX_ITER 2000
 
+/* Cache used by tests. If empty, allocate from kmalloc instead. */
+static struct kmem_cache *current_cache;
+
+static bool setup_cache(size_t size)
+{
+	/*
+	 * Use SLAB_NOLEAKTRACE to prevent merging this cache with existing
+	 * caches. Any other flag from SLAB_NEVER_MERGE except
+	 * SLAB_TYPESAFE_BY_RCU (which disables KFENCE for a cache) would also
+	 * work.
+	 * Use SLAB_ACCOUNT to allocate via memcg, if enabled.
+	 */
+	current_cache = kmem_cache_create(
+		"test_cache", size, 1, SLAB_NOLEAKTRACE | SLAB_ACCOUNT, NULL);
+	if (!current_cache)
+		return false;
+	return true;
+}
+
+static void teardown_cache(void)
+{
+	kmem_cache_destroy(current_cache);
+	current_cache = NULL;
+}
+
+static void free_to_kfence(void *ptr)
+{
+	if (!current_cache)
+		kfree(ptr);
+	else
+		kmem_cache_free(current_cache, ptr);
+}
+
 /*
- * Allocate using either kmalloc or the given memory cache till we get an object
- * from KFENCE pool or hit the maximum number of attempts.
+ * Allocate using either kmalloc or the currently used memory cache till we get
+ * an object from KFENCE pool or hit the maximum number of attempts.
  */
-static void *alloc_from_kfence(struct kmem_cache *s, size_t size, gfp_t gfp,
-			       const char *caller)
+static void *alloc_from_kfence(size_t size, gfp_t gfp, const char *caller)
 {
 	void *res;
 	int i;
 
 	for (i = 0; i < MAX_ITER; i++) {
-		if (!s)
+		if (!current_cache)
 			res = kmalloc(size, gfp);
 		else
-			res = kmem_cache_alloc(s, gfp);
+			res = kmem_cache_alloc(current_cache, gfp);
 		if (is_kfence_ptr((unsigned long)res))
 			return res;
-		if (!s)
-			kfree(res);
-		else
-			kmem_cache_free(s, res);
+		free_to_kfence(res);
 		/* TODO: sleep time depends on heartbeat period. */
 		msleep(100);
 	}
@@ -51,65 +80,80 @@ static void *alloc_from_kfence(struct kmem_cache *s, size_t size, gfp_t gfp,
 	return NULL;
 }
 
-static int do_test_oob(size_t size)
+static int do_test_oob(size_t size, bool use_cache)
 {
 	void *buffer;
 	char *c;
+	int res = 0;
 
-	buffer = alloc_from_kfence(NULL, size, GFP_KERNEL, __func__);
-	if (!buffer)
-		return 1;
-	/* We will hit KFENCE redzone at one of the buffer's ends. */
-	c = ((char *)buffer) + size + 1;
-	READ_ONCE(*c);
-	c = ((char *)buffer) - 1;
-	READ_ONCE(*c);
-	kfree(buffer);
-	return 0;
+	if (use_cache)
+		if (!setup_cache(size))
+			return 1;
+	buffer = alloc_from_kfence(size, GFP_KERNEL, __func__);
+	if (buffer) {
+		/* We will hit KFENCE redzone at one of the buffer's ends. */
+		c = ((char *)buffer) + size + 1;
+		READ_ONCE(*c);
+		c = ((char *)buffer) - 1;
+		READ_ONCE(*c);
+		free_to_kfence(buffer);
+	} else {
+		res = 1;
+	}
+	if (use_cache)
+		teardown_cache();
+	return res;
 }
 
-static int do_test_uaf(size_t size)
+static int do_test_uaf(size_t size, bool use_cache)
 {
 	void *buffer;
 	char *c;
+	int res = 0;
 
-	buffer = alloc_from_kfence(NULL, size, GFP_KERNEL, __func__);
-	if (!buffer)
-		return 1;
-	c = (char *)buffer;
-	kfree(buffer);
-	READ_ONCE(*c);
-	return 0;
+	if (use_cache)
+		if (!setup_cache(size))
+			return 1;
+	buffer = alloc_from_kfence(size, GFP_KERNEL, __func__);
+	if (buffer) {
+		c = (char *)buffer;
+		free_to_kfence(buffer);
+		READ_ONCE(*c);
+	} else {
+		res = 1;
+	}
+	if (use_cache)
+		teardown_cache();
+	return res;
 }
 
 /* Test cache creation, shrinking and destroying with KFENCE. */
 static int do_test_shrink(int size)
 {
-	struct kmem_cache *c;
 	void *buffer;
+	int res = 0;
 
-	/*
-	 * Use SLAB_NOLEAKTRACE to prevent merging this cache with existing
-	 * caches. Any other flag from SLAB_NEVER_MERGE except
-	 * SLAB_TYPESAFE_BY_RCU (which disables KFENCE for a cache) would also
-	 * work.
-	 */
-	c = kmem_cache_create("test_cache", size, 1, SLAB_NOLEAKTRACE, NULL);
-	buffer = alloc_from_kfence(c, size, GFP_KERNEL, __func__);
-	if (!buffer)
+	if (!setup_cache(size))
 		return 1;
-	kmem_cache_shrink(c);
-	kmem_cache_free(c, buffer);
-	kmem_cache_destroy(c);
-	return 0;
+	buffer = alloc_from_kfence(size, GFP_KERNEL, __func__);
+	if (buffer) {
+		kmem_cache_shrink(current_cache);
+		free_to_kfence(buffer);
+	} else {
+		res = 1;
+	}
+	teardown_cache();
+	return res;
 }
 
 static int __init test_kfence_init(void)
 {
 	int failures = 0;
 
-	failures += do_test_oob(32);
-	failures += do_test_uaf(32);
+	failures += do_test_oob(32, false);
+	failures += do_test_oob(32, true);
+	failures += do_test_uaf(32, false);
+	failures += do_test_uaf(32, true);
 	failures += do_test_shrink(32);
 
 	if (failures == 0)

--- a/mm/kfence.c
+++ b/mm/kfence.c
@@ -462,6 +462,7 @@ static void kfence_dump_object(int obj_index, struct alloc_metadata *obj)
 {
 	int size = abs(obj->size);
 	unsigned long start = kfence_obj_to_addr(obj, obj_index);
+	struct kmem_cache *cache;
 
 	pr_err("Object #%d: starts at %px, size=%d\n", obj_index, (void *)start,
 	       size);
@@ -471,6 +472,9 @@ static void kfence_dump_object(int obj_index, struct alloc_metadata *obj)
 		pr_err("freed at:\n");
 		kfence_print_stack(obj, false);
 	}
+	if ((cache = kfence_metadata[obj_index].cache) && cache->name)
+		pr_err("Object #%d belongs to cache %s\n", obj_index,
+		       cache->name);
 }
 
 static inline void kfence_report_oob(unsigned long address, int obj_index,

--- a/mm/kfence.c
+++ b/mm/kfence.c
@@ -3,14 +3,13 @@
 #include <asm/pgtable.h>
 #include <asm/tlbflush.h>
 
-#include <linux/mm.h> // required by slub_def.h, should be included there.
 #include <linux/moduleparam.h>
 #include <linux/random.h>
-#include <linux/slab.h>
-#include <linux/slub_def.h>
 #include <linux/spinlock_types.h>
 #include <linux/stackdepot.h>
 #include <linux/timer.h>
+
+#include "slab.h"
 
 /* Usually on, unless explicitly disabled. */
 static bool kfence_enabled;

--- a/mm/kfence.c
+++ b/mm/kfence.c
@@ -214,7 +214,6 @@ static bool __meminit allocate_pool(void)
 	for (i = 0; i < (2 << KFENCE_NUM_OBJ_LOG); i++) {
 		if (i && !(i % 2)) {
 			__SetPageSlab(&pages[i]);
-			pages[i].slab_cache = NULL;
 			/*
 			 * Do not add KFENCE pages to slab cache partial lists,
 			 * they will just mess up the accounting.

--- a/mm/kfence.c
+++ b/mm/kfence.c
@@ -428,7 +428,7 @@ bool kfence_free(struct kmem_cache *s, struct page *page, void *head,
 {
 	void *aligned_head = (void *)ALIGN_DOWN((unsigned long)head, PAGE_SIZE);
 
-	if (!is_kfence_ptr(addr))
+	if (!is_kfence_ptr(head))
 		return false;
 	if (KFENCE_WARN_ON(head != tail))
 		return false;

--- a/mm/kfence.c
+++ b/mm/kfence.c
@@ -439,21 +439,6 @@ bool kfence_free(struct kmem_cache *s, struct page *page, void *head,
 	return true;
 }
 
-size_t kfence_ksize(const void *object)
-{
-	unsigned long flags;
-	size_t ret;
-	int obj_index = kfence_addr_to_index((unsigned long)object);
-
-	if (obj_index == -1)
-		return 0;
-
-	spin_lock_irqsave(&kfence_alloc_lock, flags);
-	ret = abs(kfence_metadata[obj_index].size);
-	spin_unlock_irqrestore(&kfence_alloc_lock, flags);
-	return ret;
-}
-
 static void kfence_print_stack(struct alloc_metadata *obj, bool is_alloc)
 {
 	unsigned long *entries;

--- a/mm/kfence.c
+++ b/mm/kfence.c
@@ -470,7 +470,8 @@ static void kfence_dump_object(int obj_index, struct alloc_metadata *obj)
 		pr_err("freed at:\n");
 		kfence_print_stack(obj, false);
 	}
-	if ((cache = kfence_metadata[obj_index].cache) && cache->name)
+	cache = kfence_metadata[obj_index].cache;
+	if (cache && cache->name)
 		pr_err("Object #%d belongs to cache %s\n", obj_index,
 		       cache->name);
 }

--- a/mm/kfence.c
+++ b/mm/kfence.c
@@ -427,7 +427,7 @@ bool kfence_free(struct kmem_cache *s, struct page *page, void *head,
 {
 	void *aligned_head = (void *)ALIGN_DOWN((unsigned long)head, PAGE_SIZE);
 
-	if (!is_kfence_ptr(head))
+	if (!is_kfence_ptr((unsigned long)head))
 		return false;
 	if (KFENCE_WARN_ON(head != tail))
 		return false;
@@ -620,7 +620,7 @@ EXPORT_SYMBOL(kfence_cache_register);
 
 bool kfence_discard_slab(struct kmem_cache *s, struct page *page)
 {
-	if (!is_kfence_ptr(page_address(page)))
+	if (!is_kfence_ptr((unsigned long)page_address(page)))
 		return false;
 	/* Nothing here for now, but maybe we need to free the objects. */
 	return true;
@@ -710,7 +710,7 @@ void kfence_observe_memcg_cache(struct kmem_cache *memcg_cache)
 		return;
 
 	if (memcg_cache->name)
-		name = memcg_cache->name;
+		name = (char *)memcg_cache->name;
 	else
 		name = "ANON";
 

--- a/mm/kfence.c
+++ b/mm/kfence.c
@@ -253,16 +253,16 @@ error:
 	return false;
 }
 
-bool is_kfence_ptr(unsigned long addr)
+bool is_kfence_addr(unsigned long addr)
 {
 	return ((addr >= kfence_pool_start) && (addr < kfence_pool_end));
 }
-EXPORT_SYMBOL(is_kfence_ptr);
+EXPORT_SYMBOL(is_kfence_addr);
 
 /* Does not require kfence_alloc_lock. */
 static inline int kfence_addr_to_index(unsigned long addr)
 {
-	if (!is_kfence_ptr(addr))
+	if (!is_kfence_addr(addr))
 		return -1;
 
 	return ((addr - kfence_pool_start) / PAGE_SIZE / 2) - 1;
@@ -427,7 +427,7 @@ bool kfence_free(struct kmem_cache *s, struct page *page, void *head,
 {
 	void *aligned_head = (void *)ALIGN_DOWN((unsigned long)head, PAGE_SIZE);
 
-	if (!is_kfence_ptr((unsigned long)head))
+	if (!is_kfence_addr((unsigned long)head))
 		return false;
 	if (KFENCE_WARN_ON(head != tail))
 		return false;
@@ -506,7 +506,7 @@ bool kfence_handle_page_fault(unsigned long addr)
 	unsigned long flags;
 	struct alloc_metadata object = {};
 
-	if (!is_kfence_ptr(addr))
+	if (!is_kfence_addr(addr))
 		return false;
 
 	if (!READ_ONCE(kfence_enabled)) {
@@ -620,7 +620,7 @@ EXPORT_SYMBOL(kfence_cache_register);
 
 bool kfence_discard_slab(struct kmem_cache *s, struct page *page)
 {
-	if (!is_kfence_ptr((unsigned long)page_address(page)))
+	if (!is_kfence_addr((unsigned long)page_address(page)))
 		return false;
 	/* Nothing here for now, but maybe we need to free the objects. */
 	return true;

--- a/mm/slab.h
+++ b/mm/slab.h
@@ -106,6 +106,7 @@ struct memcg_cache_params {
 #include <linux/memcontrol.h>
 #include <linux/fault-inject.h>
 #include <linux/kasan.h>
+#include <linux/kfence.h>
 #include <linux/kmemleak.h>
 #include <linux/random.h>
 #include <linux/sched/mm.h>
@@ -557,6 +558,8 @@ static inline size_t slab_ksize(const struct kmem_cache *s)
 static inline struct kmem_cache *slab_pre_alloc_hook(struct kmem_cache *s,
 						     gfp_t flags)
 {
+	struct kmem_cache *memcg_cache;
+
 	flags &= gfp_allowed_mask;
 
 	fs_reclaim_acquire(flags);
@@ -568,8 +571,11 @@ static inline struct kmem_cache *slab_pre_alloc_hook(struct kmem_cache *s,
 		return NULL;
 
 	if (memcg_kmem_enabled() &&
-	    ((flags & __GFP_ACCOUNT) || (s->flags & SLAB_ACCOUNT)))
-		return memcg_kmem_get_cache(s);
+	    ((flags & __GFP_ACCOUNT) || (s->flags & SLAB_ACCOUNT))) {
+		memcg_cache = memcg_kmem_get_cache(s);
+		kfence_observe_memcg_cache(memcg_cache);
+		return memcg_cache;
+	}
 
 	return s;
 }

--- a/mm/slab.h
+++ b/mm/slab.h
@@ -558,8 +558,6 @@ static inline size_t slab_ksize(const struct kmem_cache *s)
 static inline struct kmem_cache *slab_pre_alloc_hook(struct kmem_cache *s,
 						     gfp_t flags)
 {
-	struct kmem_cache *memcg_cache;
-
 	flags &= gfp_allowed_mask;
 
 	fs_reclaim_acquire(flags);
@@ -572,7 +570,7 @@ static inline struct kmem_cache *slab_pre_alloc_hook(struct kmem_cache *s,
 
 	if (memcg_kmem_enabled() &&
 	    ((flags & __GFP_ACCOUNT) || (s->flags & SLAB_ACCOUNT))) {
-		memcg_cache = memcg_kmem_get_cache(s);
+		struct kmem_cache *memcg_cache = memcg_kmem_get_cache(s);
 		kfence_observe_memcg_cache(memcg_cache);
 		return memcg_cache;
 	}

--- a/mm/slub.c
+++ b/mm/slub.c
@@ -3977,8 +3977,7 @@ size_t __ksize(const void *object)
 	if (unlikely(!PageSlab(page))) {
 		WARN_ON(!PageCompound(page));
 		return page_size(page);
-	} else if (unlikely(page->slab_cache->flags & SLAB_KFENCE))
-		return kfence_ksize(object);
+	}
 
 	return slab_ksize(page->slab_cache);
 }


### PR DESCRIPTION
As Jann Horn once mentioned, we do not actually need `kfence_slab_cache` for any of our fast path magic. Removing it drags along other bits that are useless now.