### PR TITLE
Use canaries to detect non-fatal OOB writes.

### DIFF
--- a/include/linux/slab.h
+++ b/include/linux/slab.h
@@ -13,6 +13,7 @@
 #define	_LINUX_SLAB_H
 
 #include <linux/gfp.h>
+#include <linux/kfence.h>
 #include <linux/overflow.h>
 #include <linux/types.h>
 #include <linux/workqueue.h>
@@ -543,6 +544,7 @@ static __always_inline void *kmalloc(size_t size, gfp_t flags)
 	if (__builtin_constant_p(size)) {
 #ifndef CONFIG_SLOB
 		unsigned int index;
+		void *ret;
 #endif
 		if (size > KMALLOC_MAX_CACHE_SIZE)
 			return kmalloc_large(size, flags);
@@ -551,6 +553,16 @@ static __always_inline void *kmalloc(size_t size, gfp_t flags)
 
 		if (!index)
 			return ZERO_SIZE_PTR;
+
+		/*
+		 * TODO: __kmalloc() also calls kfence_alloc_with_size().
+		 * need to ensure it is called only once.
+		 */
+		ret = kfence_alloc_with_size(
+			kmalloc_caches[kmalloc_type(flags)][index], size,
+			flags);
+		if (ret)
+			return ret;
 
 		return kmem_cache_alloc_trace(
 				kmalloc_caches[kmalloc_type(flags)][index],

--- a/lib/test_kfence.c
+++ b/lib/test_kfence.c
@@ -132,58 +132,53 @@ static int do_test_kmalloc_aligned_oob_read(void)
 {
 	void *buffer;
 	char *c;
-	int res = 0;
 	const size_t size = 73;
 
 	buffer = alloc_from_kfence(size, GFP_KERNEL, SIDE_RIGHT, __func__);
-	if (buffer) {
-		/*
+	if (!buffer)
+		return 1;
+	/*
 		 * The object is offset to the right, so there won't be OOBs to
 		 * the left of it.
 		 */
-		c = ((char *)buffer) - 1;
-		READ_ONCE(*c);
+	c = ((char *)buffer) - 1;
+	READ_ONCE(*c);
 
-		/*
+	/*
 		 * @buffer must be aligned on 8, therefore buffer + size + 1
 		 * belongs to the same page - no immediate OOB.
 		 */
-		c = ((char *)buffer) + size + 1;
-		READ_ONCE(*c);
+	c = ((char *)buffer) + size + 1;
+	READ_ONCE(*c);
 
-		/* Overflowing the buffer by 8 bytes will result in an OOB. */
-		c = ((char *)buffer) + size + 8;
-		READ_ONCE(*c);
+	/* Overflowing the buffer by 8 bytes will result in an OOB. */
+	c = ((char *)buffer) + size + 8;
+	READ_ONCE(*c);
 
-		free_to_kfence(buffer);
-	} else {
-		res = 1;
-	}
-	return res;
+	free_to_kfence(buffer);
+	return 0;
 }
 
 static int do_test_kmalloc_aligned_oob_write(void)
 {
 	void *buffer;
 	unsigned char *c, value;
-	int res = 0;
 	const size_t size = 73;
 
 	buffer = alloc_from_kfence(size, GFP_KERNEL, SIDE_RIGHT, __func__);
-	if (buffer) {
-		/*
+	if (!buffer)
+		return 1;
+
+	/*
 		 * The object is offset to the right, so we won't get a page
 		 * fault immediately after it.
 		 */
-		c = ((char *)buffer) + size + 1;
-		value = READ_ONCE(*c);
-		WRITE_ONCE(*c, value + 1);
+	c = ((char *)buffer) + size + 1;
+	value = READ_ONCE(*c);
+	WRITE_ONCE(*c, value + 1);
 
-		free_to_kfence(buffer);
-	} else {
-		res = 1;
-	}
-	return res;
+	free_to_kfence(buffer);
+	return 0;
 }
 
 static int do_test_uaf(size_t size, bool use_cache)

--- a/mm/kfence/core.c
+++ b/mm/kfence/core.c
@@ -290,6 +290,8 @@ void *kfence_guarded_alloc(struct kmem_cache *cache, size_t override_size,
 			kfence_unprotect((unsigned long)obj);
 
 		kfence_metadata[index].addr = (unsigned long)ret;
+		if (gfp & __GFP_ZERO)
+			memset(ret, 0, size);
 		/*
 		 * Reclaiming memory when storing stacks may result in
 		 * unnecessary locking.

--- a/mm/kfence/core.c
+++ b/mm/kfence/core.c
@@ -255,9 +255,7 @@ size_t kfence_ksize(const void *addr)
 	return abs(READ_ONCE(kfence_metadata[index].size));
 }
 
-static void kfence_report_corruption(unsigned long address);
-
-void set_or_check_canary_byte(unsigned long addr, bool set)
+static void set_or_check_canary_byte(unsigned long addr, bool set)
 {
 	const char pattern[] = { 0xAA, 0xAB, 0xAA, 0xAD };
 	char p = pattern[addr % ARRAY_SIZE(pattern)];
@@ -269,7 +267,7 @@ void set_or_check_canary_byte(unsigned long addr, bool set)
 	}
 }
 
-void set_or_check_canaries(int index, bool set)
+static void set_or_check_canaries(int index, bool set)
 {
 	unsigned long start = kfence_metadata[index].addr;
 	int size = abs(kfence_metadata[index].size);

--- a/mm/kfence/core.h
+++ b/mm/kfence/core.h
@@ -9,6 +9,7 @@ void *kfence_guarded_alloc(struct kmem_cache *cache, size_t override_size,
 void kfence_guarded_free(void *addr);
 void kfence_disable(void);
 bool __meminit kfence_allocate_pool(void);
+static void kfence_report_corruption(unsigned long address);
 
 /* Should be provided by the sampling algorithm implementation. */
 void kfence_impl_init(void);

--- a/mm/kfence/naive.c
+++ b/mm/kfence/naive.c
@@ -27,6 +27,7 @@ void *kfence_alloc_with_size(struct kmem_cache *s, size_t size, gfp_t flags)
 
 	return ret;
 }
+EXPORT_SYMBOL(kfence_alloc_with_size);
 
 void kfence_impl_init(void)
 {

--- a/mm/kfence/naive.c
+++ b/mm/kfence/naive.c
@@ -12,7 +12,6 @@ void *kfence_alloc_with_size(struct kmem_cache *s, size_t size, gfp_t flags)
 {
 	u32 rnd;
 	void *ret;
-	unsigned long aligned_ret;
 
 	if (!READ_ONCE(kfence_enabled))
 		return NULL;
@@ -26,11 +25,6 @@ void *kfence_alloc_with_size(struct kmem_cache *s, size_t size, gfp_t flags)
 		return NULL;
 	ret = kfence_guarded_alloc(s, size, flags);
 
-	/* TODO: account for init_on_alloc=1 as well. */
-	if (ret && (flags & __GFP_ZERO)) {
-		aligned_ret = ALIGN_DOWN((unsigned long)ret, PAGE_SIZE);
-		memset((void *)aligned_ret, 0, PAGE_SIZE);
-	}
 	return ret;
 }
 

--- a/mm/slub.c
+++ b/mm/slub.c
@@ -3977,6 +3977,10 @@ void *__kmalloc_node(size_t size, gfp_t flags, int node)
 	if (unlikely(ZERO_OR_NULL_PTR(s)))
 		return s;
 
+	ret = kfence_alloc_with_size(s, size, flags);
+	if (ret)
+		return ret;
+
 	ret = slab_alloc_node(s, flags, node, _RET_IP_);
 
 	trace_kmalloc_node(_RET_IP_, ret, size, s->size, flags, node);


### PR DESCRIPTION
See https://github.com/google/kasan/issues/79