### PR TITLE
Use a single inline function for sampled allocations

### DIFF
--- a/include/linux/kfence.h
+++ b/include/linux/kfence.h
@@ -43,7 +43,8 @@ static inline size_t kfence_ksize(void *addr) { return 0; }
 #endif /* CONFIG_KFENCE */
 
 #ifdef CONFIG_KFENCE_STEAL
-void *kfence_alloc_and_fix_freelist(struct kmem_cache *s, gfp_t gfp);
+void *kfence_alloc_and_fix_freelist(struct kmem_cache *s, gfp_t gfp,
+				    unsigned long addr);
 
 void kfence_cache_register(struct kmem_cache *s);
 
@@ -55,7 +56,7 @@ void kfence_observe_memcg_cache(struct kmem_cache *memcg_cache);
 // TODO: remove for v1
 // clang-format off
 
-static inline void *kfence_alloc_and_fix_freelist(struct kmem_cache *s, gfp_t gfp) { return NULL; }
+static inline void *kfence_alloc_and_fix_freelist(struct kmem_cache *s, gfp_t gfp, unsigned long addr) { return NULL; }
 static inline void kfence_cache_register(struct kmem_cache *s)   { }
 static inline void kfence_cache_unregister(struct kmem_cache *s) { }
 static inline void kfence_observe_memcg_cache(struct kmem_cache *memcg_cache) { }

--- a/mm/kfence/naive.c
+++ b/mm/kfence/naive.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 
 #include <linux/mm.h>
-#include <linux/percpu-defs.h>
+#include <linux/percpu.h>
 
 #include "kfence.h"
 #include "../slab.h"
@@ -17,10 +17,6 @@ void *kfence_alloc_with_size(struct kmem_cache *s, size_t size, gfp_t flags)
 	int cnt;
 	void *ret;
 
-	cnt = this_cpu_dec_return(kfence_sample_cnt);
-	if (cnt > 0)
-		return NULL;
-	this_cpu_write(kfence_sample_cnt, kfence_sample_rate);
 
 	if (!kfence_is_enabled())
 		return NULL;

--- a/mm/kfence/report.c
+++ b/mm/kfence/report.c
@@ -105,6 +105,22 @@ static void kfence_print_object(int obj_index,
 	pr_err("%s", kfence_dump_buf);
 }
 
+#define BYTES_TO_DUMP 16
+static void dump_bytes_at(unsigned long addr)
+{
+	unsigned char *c = (unsigned char *)addr;
+	unsigned char *max_addr = (unsigned char *)min(ALIGN(addr, PAGE_SIZE),
+						       addr + BYTES_TO_DUMP);
+	char bytes[BYTES_TO_DUMP * 3 + 1];
+	int len = 0;
+
+	for (; c < max_addr; c++)
+		len += scnprintf(bytes + len, sizeof(bytes) - len, "%02X ", *c);
+
+	pr_err("Bytes at %px: %s\n", (void *)addr, bytes);
+}
+#undef BYTES_TO_DUMP
+
 void kfence_report_error(unsigned long address, int obj_index,
 			 struct kfence_alloc_metadata *object,
 			 enum kfence_error_type type)
@@ -134,6 +150,7 @@ void kfence_report_error(unsigned long address, int obj_index,
 		       (void *)stack_entries[skipnr]);
 		pr_err("Invalid write detected at address %px\n",
 		       (void *)address);
+		dump_bytes_at(address);
 		break;
 	}
 

--- a/mm/slub.c
+++ b/mm/slub.c
@@ -2609,7 +2609,7 @@ static void *___slab_alloc(struct kmem_cache *s, gfp_t gfpflags, int node,
 	struct page *page;
 	void *ret;
 
-	ret = kfence_alloc_and_fix_freelist(s, gfpflags);
+	ret = kfence_alloc_and_fix_freelist(s, gfpflags, addr);
 	if (ret)
 		return ret;
 

--- a/mm/slub.c
+++ b/mm/slub.c
@@ -2817,6 +2817,9 @@ redo:
 	if (unlikely(!object || !node_match(page, node))) {
 		object = __slab_alloc(s, gfpflags, node, addr, c);
 		stat(s, ALLOC_SLOWPATH);
+		/* Skip initialization for KFENCE objects. */
+		if (is_kfence_addr(object))
+			goto leave;
 	} else {
 		void *next_object = get_freepointer_safe(s, object);
 
@@ -2851,6 +2854,7 @@ redo:
 	if (unlikely(slab_want_init_on_alloc(gfpflags, s)) && object)
 		memset(object, 0, s->object_size);
 
+leave:
 	slab_post_alloc_hook(s, gfpflags, 1, &object);
 
 	return object;


### PR DESCRIPTION
Use a per-CPU sample counter, adding a single load and a branch to the fast path.
kmalloc() requires some plumbing - we pass the requested size via `_RET_IP_` now.
This might be a bit questionable, but ends up being almost non-intrusive.