### PR TITLE
kfence: Rework object printing

### DIFF
--- a/mm/kfence/core.c
+++ b/mm/kfence/core.c
@@ -34,9 +34,6 @@ static unsigned long kfence_pool_start, kfence_pool_end;
 /* Protects kfence_freelist, kfence_recycle, kfence_metadata */
 static DEFINE_SPINLOCK(kfence_alloc_lock);
 
-/* Size picked to accommodate the metadata of a single KFENCE object. */
-char kfence_dump_buf[PAGE_SIZE * 2];
-
 /*
  * kfence_freelist is a wrapper around kfence page pointers that allows
  * chaining them.
@@ -488,10 +485,10 @@ static int obj_show(struct seq_file *seq, void *v)
 	unsigned long flags;
 
 	spin_lock_irqsave(&kfence_alloc_lock, flags);
-	kfence_dump_object(kfence_dump_buf, sizeof(kfence_dump_buf), index,
-			   &kfence_metadata[index]);
+	kfence_dump_object(seq, index, &kfence_metadata[index]);
 	spin_unlock_irqrestore(&kfence_alloc_lock, flags);
-	seq_printf(seq, "%s\n", kfence_dump_buf);
+	seq_printf(seq, "---------------------------------\n");
+
 	return 0;
 }
 

--- a/mm/kfence/kfence.h
+++ b/mm/kfence/kfence.h
@@ -4,6 +4,7 @@
 #define MM_KFENCE_KFENCE_H
 
 #include <linux/mm.h>
+#include <linux/seq_file.h>
 #include <linux/stackdepot.h>
 #include <linux/types.h>
 
@@ -47,7 +48,6 @@ struct kfence_alloc_metadata {
 extern bool kfence_enabled;
 extern unsigned long kfence_sample_rate;
 extern struct kfence_alloc_metadata *kfence_metadata;
-extern char kfence_dump_buf[PAGE_SIZE * 2];
 
 static inline bool kfence_is_enabled(void)
 {
@@ -70,8 +70,8 @@ void kfence_report_error(unsigned long address, int obj_index,
 			 struct kfence_alloc_metadata *metadata,
 			 enum kfence_error_type type);
 
-int kfence_dump_object(char *buf, size_t buf_size, int obj_index,
-		       struct kfence_alloc_metadata *obj);
+void kfence_dump_object(struct seq_file *seq, int obj_index,
+			struct kfence_alloc_metadata *obj);
 
 /* Should be provided by the sampling algorithm implementation. */
 void kfence_impl_init(void);


### PR DESCRIPTION
Remove kfence_dump_buf and rework how objects are printed to either
seq_files or to console.