### PR TITLE
kfence: Implement static key based sampling method

### DIFF
--- a/include/linux/kfence.h
+++ b/include/linux/kfence.h
@@ -84,6 +84,21 @@ kfence_sampled_alloc_with_size(struct kmem_cache *s, gfp_t flags, size_t size)
 	return kfence_alloc_with_size(s, size, flags);
 }
 
+#elif defined(CONFIG_KFENCE_STATIC_KEY)
+
+#include <linux/static_key.h>
+
+extern struct static_key_false kfence_allocation_key;
+
+void *kfence_alloc_with_size(struct kmem_cache *s, size_t size, gfp_t flags);
+static __always_inline void *
+kfence_sampled_alloc_with_size(struct kmem_cache *s, gfp_t flags, size_t size)
+{
+	return static_branch_unlikely(&kfence_allocation_key) ?
+			     kfence_alloc_with_size(s, size, flags) :
+			     NULL;
+}
+
 #else
 
 // TODO: remove for v1

--- a/include/linux/kfence.h
+++ b/include/linux/kfence.h
@@ -20,6 +20,7 @@ bool kfence_discard_slab(struct kmem_cache *s, struct page *page);
 
 bool kfence_handle_page_fault(unsigned long addr);
 
+// TODO(elver): Make is_kfence_addr inlinable.
 bool is_kfence_addr(void *addr);
 
 size_t kfence_ksize(const void *addr);
@@ -90,7 +91,16 @@ kfence_sampled_alloc_with_size(struct kmem_cache *s, gfp_t flags, size_t size)
 
 extern struct static_key_false kfence_allocation_key;
 
+// TODO(elver): The order of size,flags is inconsistent between the 2 functions.
+// Fix it by preferring size,flags throughout (which is kmalloc's argument
+// order).
+
+// TODO(elver): Shorten function names, and make kfence_alloc_with_size private.
+// Simply rename them to __kfence_alloc and kfence_alloc respectively.
+
 void *kfence_alloc_with_size(struct kmem_cache *s, size_t size, gfp_t flags);
+
+// TODO(elver): Add API doc.
 static __always_inline void *
 kfence_sampled_alloc_with_size(struct kmem_cache *s, gfp_t flags, size_t size)
 {

--- a/lib/Kconfig.kfence
+++ b/lib/Kconfig.kfence
@@ -41,4 +41,11 @@ config KFENCE_NAIVE
 	  Adds branches to allocation sites to call KFENCE with a certain
 	  probability.
 
+config KFENCE_STATIC_KEY
+	bool "Static key implementation"
+	depends on JUMP_LABEL # To ensure performance, require jump labels
+	help
+	  Adds static keys to allocation sites to call KFENCE with a certain
+	  probability.
+
 endchoice

--- a/mm/kfence/Makefile
+++ b/mm/kfence/Makefile
@@ -3,3 +3,4 @@
 obj-$(CONFIG_KFENCE) := core.o report.o
 obj-$(CONFIG_KFENCE_STEAL) += steal.o
 obj-$(CONFIG_KFENCE_NAIVE) += naive.o
+obj-$(CONFIG_KFENCE_STATIC_KEY) += static_key.o

--- a/mm/kfence/static_key.c
+++ b/mm/kfence/static_key.c
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0
+
+#include <linux/atomic.h>
+#include <linux/mm.h>
+#include <linux/static_key.h>
+#include <linux/wait.h>
+#include <linux/workqueue.h>
+
+#include "kfence.h"
+#include "../slab.h"
+
+/* The static key to set up a KFENCE allocation. */
+DEFINE_STATIC_KEY_FALSE(kfence_allocation_key);
+
+/* Gates the allocation, ensuring only one succeeds in a given period. */
+static atomic_t allocation_gate = ATOMIC_INIT(1);
+/* Wait queue to wake up heartbeat timer task. */
+static DECLARE_WAIT_QUEUE_HEAD(allocation_wait);
+
+void *kfence_alloc_with_size(struct kmem_cache *s, size_t size, gfp_t flags)
+{
+	void *ret;
+
+	/*
+	 * allocation_gate only needs to become non-zero, so it doesn't make
+	 * sense to continue writing to it and pay the associated contention
+	 * cost, in case we have a large number of concurrent allocations.
+	 */
+	if (atomic_read(&allocation_gate) || atomic_inc_return(&allocation_gate) > 1)
+		return NULL;
+	wake_up(&allocation_wait);
+
+	if (!kfence_is_enabled())
+		return NULL;
+
+	// TODO(elver): Remove one of the comparisons, which is redundant.
+	if ((size > PAGE_SIZE) || (s->size > PAGE_SIZE))
+		return NULL;
+	if (s->ctor || (s->flags & SLAB_TYPESAFE_BY_RCU))
+		return NULL;
+
+	ret = kfence_guarded_alloc(s, size, flags);
+
+	return ret;
+}
+
+/*
+ * Set up delayed work, which will enable and disable the static key. We need to
+ * use a work queue (rather than a simple timer), since enabling and disabling a
+ * static key cannot be done from an interrupt.
+ */
+static struct delayed_work kfence_timer;
+static void kfence_heartbeat(struct work_struct *work)
+{
+	if (!kfence_is_enabled())
+		return;
+
+	/* Enable static key, and await allocation to happen. */
+	atomic_set(&allocation_gate, 0);
+	static_branch_enable(&kfence_allocation_key);
+	wait_event(allocation_wait, atomic_read(&allocation_gate) != 0);
+
+	/* Disable static key and reset timer. */
+	static_branch_disable(&kfence_allocation_key);
+	schedule_delayed_work(&kfence_timer, msecs_to_jiffies(kfence_sample_rate));
+}
+static DECLARE_DELAYED_WORK(kfence_timer, kfence_heartbeat);
+
+/*
+ * TODO: naive implementation doesn't strictly require waiting for RNG anymore.
+ */
+void kfence_impl_init(void)
+{
+	schedule_delayed_work(&kfence_timer, 0);
+}


### PR DESCRIPTION
This implements a sampling based method using static keys aka. jump
labels. Jump labels use code patching to turn on or off branches at
runtime. Typically the cost of enabling or disabling is high due to
IPIs, however, even with the default sample rate of 100ms, no measurable
performance degradation can be observed.

Doing a simple sysbench run shows that the overhead is negligible and no
performance difference to the non-KFENCE version is noticable. More
detailed results from sysbench run here:
https://github.com/google/kasan/issues/72

My proposal is that we make this variant the main sampling method of
interest, and if it survives further testing, remove all other sampling
methods in favor of simply having this one. This should hopefully also
get us closer to the preparation of a patch series for LKML.