### PR TITLE
kfence: get rid of stack depot

### DIFF
--- a/lib/Kconfig.kfence
+++ b/lib/Kconfig.kfence
@@ -10,7 +10,6 @@ config TEST_KFENCE
 config KFENCE
 	bool "KFence: low-overhead use-after-free and buffer-overflow detector"
 	depends on HAVE_ARCH_KFENCE && !KASAN
-	select STACKDEPOT
 	help
 	  KFence is low-overhead sampling-based detector for heap
 	  use-after-free and buffer-overflow errors. KFence is designed to have

--- a/mm/kfence/kfence.h
+++ b/mm/kfence/kfence.h
@@ -5,7 +5,6 @@
 
 #include <linux/mm.h>
 #include <linux/seq_file.h>
-#include <linux/stackdepot.h>
 #include <linux/types.h>
 
 #include "../slab.h"
@@ -24,8 +23,8 @@
 
 enum kfence_object_state { KFENCE_OBJECT_UNUSED, KFENCE_OBJECT_ALLOCATED, KFENCE_OBJECT_FREED };
 
+#define KFENCE_STACK_DEPTH 64
 struct kfence_alloc_metadata {
-	depot_stack_handle_t alloc_stack, free_stack;
 	struct kmem_cache *cache;
 	/*
 	 * Size may be read without a lock in ksize(). We assume that ksize() is
@@ -39,6 +38,9 @@ struct kfence_alloc_metadata {
 	 */
 	unsigned long addr;
 	enum kfence_object_state state;
+	unsigned long nr_alloc, nr_free;
+	unsigned long stack_alloc[KFENCE_STACK_DEPTH];
+	unsigned long stack_free[KFENCE_STACK_DEPTH];
 };
 
 extern bool kfence_enabled;

--- a/mm/kfence/report.c
+++ b/mm/kfence/report.c
@@ -66,9 +66,10 @@ static int get_stack_skipnr(const unsigned long stack_entries[], int num_entries
 static void kfence_dump_stack(struct seq_file *seq, struct kfence_alloc_metadata *obj,
 			      bool is_alloc)
 {
-	const depot_stack_handle_t handle = is_alloc ? obj->alloc_stack : obj->free_stack;
+	unsigned long *entries = is_alloc ? obj->stack_alloc : obj->stack_free;
+	unsigned long nr_entries = is_alloc ? obj->nr_alloc : obj->nr_free;
 
-	if (handle) {
+	if (nr_entries) {
 		/*
 		 * Unfortunately stack_trace_seq_print() does not exist, and we
 		 * require a temporary buffer for printing the stack trace. We
@@ -76,10 +77,7 @@ static void kfence_dump_stack(struct seq_file *seq, struct kfence_alloc_metadata
 		 * under the KFENCE lock.
 		 */
 		static char buf[PAGE_SIZE];
-		unsigned long *entries;
-		unsigned long nr_entries;
 
-		nr_entries = stack_depot_fetch(handle, &entries);
 		stack_trace_snprint(buf, sizeof(buf), entries, nr_entries, 0);
 		seq_con_printf(seq, "%s\n", buf);
 	} else {


### PR DESCRIPTION
Unlike other debugging tools, we have a fixed number of allocations to
care about, so we'd better store the stacks ourselves to avoid the
growing memory consumption of stackdepot.

Fixes https://github.com/google/kasan/issues/66

Signed-off-by: Alexander Potapenko <glider@google.com>