### PR TITLE
kfence: statically allocate the memory pool

### DIFF
--- a/include/linux/kfence.h
+++ b/include/linux/kfence.h
@@ -18,9 +18,9 @@ struct kmem_cache;
 #define KFENCE_NUM_OBJ_LOG 8
 #define KFENCE_NUM_OBJ ((1 << KFENCE_NUM_OBJ_LOG) - 1)
 
-extern unsigned long __kfence_pool_start;
+extern char __kfence_pool_start[];
 
-static inline unsigned long __kfence_pool_end(void)
+static inline char *__kfence_pool_end(void)
 {
 	return __kfence_pool_start + (KFENCE_NUM_OBJ + 1) * 2 * PAGE_SIZE;
 }
@@ -36,9 +36,7 @@ bool kfence_handle_page_fault(unsigned long addr);
 
 static inline bool is_kfence_addr(void *addr)
 {
-	const unsigned long uaddr = (unsigned long)addr;
-
-	return unlikely(uaddr >= __kfence_pool_start && uaddr < __kfence_pool_end());
+	return unlikely((char *)addr >= __kfence_pool_start && (char *)addr < __kfence_pool_end());
 }
 
 size_t kfence_ksize(const void *addr);

--- a/mm/kfence/core.c
+++ b/mm/kfence/core.c
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 
+#include <asm/pgalloc.h>
+
 #include <linux/debugfs.h>
 #include <linux/kfence.h>
 #include <linux/list.h>
@@ -23,7 +25,8 @@ struct kfence_freelist {
 	void *obj;
 };
 
-unsigned long __kfence_pool_start;
+char __kfence_pool_start[PAGE_SIZE << (KFENCE_NUM_OBJ_LOG + 1)]
+	__attribute__((section(".kfence"), aligned(1 << 21)));
 EXPORT_SYMBOL(__kfence_pool_start);
 
 /* Protects kfence_freelist, kfence_recycle, kfence_metadata */
@@ -71,31 +74,135 @@ noinline void kfence_disable(void)
 	WRITE_ONCE(kfence_enabled, false);
 }
 
-/* TODO(glider): kernel_physical_mapping_change() is x86-only */
-unsigned long kernel_physical_mapping_change(unsigned long start, unsigned long end,
-					     unsigned long page_size_mask);
-
-static bool kfence_force_4k_pages(void)
+static pgprot_t pgprot_clear_protnone_bits(pgprot_t prot)
 {
-	unsigned long addr = __kfence_pool_start, addr_end;
+	/*
+	 * _PAGE_GLOBAL means "global page" for present PTEs.
+	 * But, it is also used to indicate _PAGE_PROTNONE
+	 * for non-present PTEs.
+	 *
+	 * This ensures that a _PAGE_GLOBAL PTE going from
+	 * present to non-present is not confused as
+	 * _PAGE_PROTNONE.
+	 */
+	if (!(pgprot_val(prot) & _PAGE_PRESENT))
+		pgprot_val(prot) &= ~_PAGE_GLOBAL;
+
+	return prot;
+}
+
+/* Some code borrowed from arch/x86/mm/pat/set_memory.c. */
+static bool split_large_page(pte_t *kpte, unsigned long address, unsigned int level)
+{
+	unsigned long lpaddr, lpinc, ref_pfn, pfn, pfninc = 1;
+	pte_t *pbase;
+	unsigned int i;
+	pgprot_t ref_prot;
+	struct page *base;
+
+	base = alloc_pages(GFP_KERNEL, 0);
+	if (!base)
+		return false;
+	pbase = (pte_t *)page_address(base);
+
+	spin_lock(&pgd_lock);
+	paravirt_alloc_pte(&init_mm, page_to_pfn(base));
+
+	switch (level) {
+	case PG_LEVEL_2M:
+		ref_prot = pmd_pgprot(*(pmd_t *)kpte);
+		/*
+		 * Clear PSE (aka _PAGE_PAT) and move
+		 * PAT bit to correct position.
+		 */
+		ref_prot = pgprot_large_2_4k(ref_prot);
+		ref_pfn = pmd_pfn(*(pmd_t *)kpte);
+		lpaddr = address & PMD_MASK;
+		lpinc = PAGE_SIZE;
+		break;
+
+	case PG_LEVEL_1G:
+		ref_prot = pud_pgprot(*(pud_t *)kpte);
+		ref_pfn = pud_pfn(*(pud_t *)kpte);
+		pfninc = PMD_PAGE_SIZE >> PAGE_SHIFT;
+		lpaddr = address & PUD_MASK;
+		lpinc = PMD_SIZE;
+		/*
+		 * Clear the PSE flags if the PRESENT flag is not set
+		 * otherwise pmd_present/pmd_huge will return true
+		 * even on a non present pmd.
+		 */
+		if (!(pgprot_val(ref_prot) & _PAGE_PRESENT))
+			pgprot_val(ref_prot) &= ~_PAGE_PSE;
+		break;
+
+	default:
+		spin_unlock(&pgd_lock);
+		__free_page(base);
+		return false;
+	}
+
+	ref_prot = pgprot_clear_protnone_bits(ref_prot);
+
+	/*
+	 * Get the target pfn from the original entry:
+	 */
+	pfn = ref_pfn;
+	for (i = 0; i < PTRS_PER_PTE; i++, pfn += pfninc, lpaddr += lpinc)
+		set_pte(pbase + i, pfn_pte(pfn, ref_prot));
+
+	/*
+	 * Install the new, split up pagetable.
+	 *
+	 * We use the standard kernel pagetable protections for the new
+	 * pagetable protections, the actual ptes set above control the
+	 * primary protection behavior:
+	 */
+	/*
+	 * TODO(glider): for x86_32 see __set_pmd_pte() in
+	 * arch/x86/mm/pat/set_memory.c
+	 */
+	set_pte_atomic(kpte, mk_pte(base, __pgprot(_KERNPG_TABLE)));
+
+	/*
+	 * Do a global flush tlb after splitting the large page
+	 * and before we do the actual change page attribute in the PTE.
+	 *
+	 * Without this, we violate the TLB application note, that says:
+	 * "The TLBs may contain both ordinary and large-page
+	 *  translations for a 4-KByte range of linear addresses. This
+	 *  may occur if software modifies the paging structures so that
+	 *  the page size used for the address range changes. If the two
+	 *  translations differ with respect to page frame or attributes
+	 *  (e.g., permissions), processor behavior is undefined and may
+	 *  be implementation-specific."
+	 *
+	 * We do this global tlb flush inside the cpa_lock, so that we
+	 * don't allow any other cpu, with stale tlb entries change the
+	 * page attribute in parallel, that also falls into the
+	 * just split large page entry.
+	 */
+	flush_tlb_all();
+	spin_unlock(&pgd_lock);
+
+	return true;
+}
+
+bool kfence_force_4k_pages(unsigned long addr)
+{
 	unsigned int level;
-	unsigned long psize, pmask;
 	pte_t *pte;
 
-	while (addr < __kfence_pool_end()) {
+	while (addr < (unsigned long)__kfence_pool_end()) {
 		pte = lookup_address(addr, &level);
 		if (!pte)
 			return false;
-		if (level != PG_LEVEL_4K) {
-			psize = page_level_size(level);
-			pmask = page_level_mask(level);
-			addr_end = ((addr + PAGE_SIZE) & pmask) + psize;
-			kernel_physical_mapping_change(__pa(addr & pmask), __pa(addr_end),
-						       1 << PG_LEVEL_4K);
-			addr = addr_end;
-		} else {
+		if (level == PG_LEVEL_4K) {
 			addr += PAGE_SIZE;
+			continue;
 		}
+		if (!split_large_page(pte, addr, level))
+			return false;
 	}
 	flush_tlb_all();
 	return true;
@@ -133,18 +240,16 @@ static bool __meminit kfence_allocate_pool(void)
 {
 	struct page *pages = NULL;
 	struct kfence_freelist *objects = NULL;
-	unsigned long addr;
+	unsigned long addr = (unsigned long)__kfence_pool_start;
 	int i;
 	gfp_t gfp_flags = GFP_KERNEL | __GFP_ZERO;
 
-	pages = alloc_pages(GFP_KERNEL, KFENCE_NUM_OBJ_LOG + 1);
-	if (!pages)
+	pages = virt_to_page(addr);
+	if (!kfence_force_4k_pages(addr))
 		goto error;
-	__kfence_pool_start = (unsigned long)page_address(pages);
-	if (!kfence_force_4k_pages())
-		goto error;
-	pr_info("kfence allocated pages: %px--%px\n",
-		(void *)__kfence_pool_start, (void *)__kfence_pool_end());
+	pr_info("kfence allocated pages: %px--%px\n", (void *)__kfence_pool_start,
+		(void *)__kfence_pool_end());
+
 	/*
 	 * Set up non-redzone pages: they must have PG_slab flag and point to
 	 * kfence slab cache.
@@ -159,7 +264,6 @@ static bool __meminit kfence_allocate_pool(void)
 			pages[i].frozen = 1;
 		}
 	}
-	addr = __kfence_pool_start;
 	/* Skip the first page: it is reserved. */
 	addr += PAGE_SIZE;
 	/* Protect the leading redzone. */
@@ -186,8 +290,6 @@ static bool __meminit kfence_allocate_pool(void)
 		goto error;
 	return true;
 error:
-	if (pages)
-		__free_pages(pages, KFENCE_NUM_OBJ_LOG + 1);
 	kfree(objects);
 	kfree(kfence_metadata);
 	return false;
@@ -199,7 +301,7 @@ static inline int kfence_addr_to_index(unsigned long addr)
 	if (!is_kfence_addr((void *)addr))
 		return -1;
 
-	return ((addr - __kfence_pool_start) / PAGE_SIZE / 2) - 1;
+	return ((addr - (unsigned long)__kfence_pool_start) / PAGE_SIZE / 2) - 1;
 }
 
 size_t kfence_ksize(const void *addr)
@@ -345,15 +447,11 @@ void kfence_guarded_free(void *addr)
 bool kfence_free(struct kmem_cache *s, struct page *page, void *head, void *tail, int cnt,
 		 unsigned long addr)
 {
-	void *aligned_head = (void *)ALIGN_DOWN((unsigned long)head, PAGE_SIZE);
-
 	if (!is_kfence_addr(head))
 		return false;
 	if (KFENCE_WARN_ON(head != tail))
 		return false;
 	pr_debug("kfence_free(%px)\n", head);
-	if (KFENCE_WARN_ON(aligned_head != page_address(page)))
-		return false;
 	kfence_guarded_free(head);
 	return true;
 }
@@ -373,7 +471,7 @@ bool kfence_handle_page_fault(unsigned long addr)
 	}
 
 	spin_lock_irqsave(&kfence_alloc_lock, flags);
-	page_index = (addr - __kfence_pool_start) / PAGE_SIZE;
+	page_index = (addr - (unsigned long)__kfence_pool_start) / PAGE_SIZE;
 	if (page_index % 2) {
 		/* This is a redzone, report a buffer overflow. */
 		if (page_index > 1) {

--- a/mm/kfence/core.c
+++ b/mm/kfence/core.c
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
 
-#include <asm/pgalloc.h>
-
 #include <linux/debugfs.h>
 #include <linux/kfence.h>
 #include <linux/list.h>
@@ -11,6 +9,7 @@
 #include <linux/slab.h>
 #include <linux/spinlock.h>
 
+#include <asm/pgalloc.h>
 #include <asm/pgtable.h>
 #include <asm/tlbflush.h>
 
@@ -25,7 +24,7 @@ struct kfence_freelist {
 	void *obj;
 };
 
-char __kfence_pool_start[PAGE_SIZE << (KFENCE_NUM_OBJ_LOG + 1)] __attribute__((aligned(2 << 21)));
+char __kfence_pool_start[PAGE_SIZE << (KFENCE_NUM_OBJ_LOG + 1)] __aligned(2 << 21);
 EXPORT_SYMBOL(__kfence_pool_start);
 
 /* Protects kfence_freelist, kfence_recycle, kfence_metadata */
@@ -90,7 +89,11 @@ static pgprot_t pgprot_clear_protnone_bits(pgprot_t prot)
 	return prot;
 }
 
-/* Some code borrowed from arch/x86/mm/pat/set_memory.c. */
+/*
+ * Some code borrowed from arch/x86/mm/pat/set_memory.c.
+ * TODO(glider): need to figure out whether this code can be used on ARM64 and change it
+ * accordingly.
+ */
 static bool split_large_page(pte_t *kpte, unsigned long address, unsigned int level)
 {
 	unsigned long lpaddr, lpinc, ref_pfn, pfn, pfninc = 1;

--- a/mm/kfence/core.c
+++ b/mm/kfence/core.c
@@ -25,8 +25,7 @@ struct kfence_freelist {
 	void *obj;
 };
 
-char __kfence_pool_start[PAGE_SIZE << (KFENCE_NUM_OBJ_LOG + 1)]
-	__attribute__((section(".kfence"), aligned(1 << 21)));
+char __kfence_pool_start[PAGE_SIZE << (KFENCE_NUM_OBJ_LOG + 1)] __attribute__((aligned(2 << 21)));
 EXPORT_SYMBOL(__kfence_pool_start);
 
 /* Protects kfence_freelist, kfence_recycle, kfence_metadata */


### PR DESCRIPTION
Making __kfence_pool_start an array in the data section allows us to
check whether an address belongs to it or not without doing memory
loads.

This also required fixing kfence_force_4k_pages(), which didn't work
initially.

Signed-off-by: Alexander Potapenko <glider@google.com>