### PR TITLE
kfence: Fix get_stack_skipnr() with tail call optimization

### DIFF
--- a/mm/kfence/core.c
+++ b/mm/kfence/core.c
@@ -147,10 +147,10 @@ static noinline void metadata_update_state(struct kfence_metadata *meta,
 {
 	unsigned long *entries = next == KFENCE_OBJECT_FREED ? meta->free_stack : meta->alloc_stack;
 	/*
-	 * Skip over 2 (this, caller) functions; noinline ensures we do not
-	 * accidentally skip over the caller by never inlining.
+	 * Skip over 1 (this) functions; noinline ensures we do not accidentally
+	 * skip over the caller by never inlining.
 	 */
-	const int nentries = stack_trace_save(entries, KFENCE_STACK_DEPTH, 2);
+	const int nentries = stack_trace_save(entries, KFENCE_STACK_DEPTH, 1);
 
 	lockdep_assert_held(&meta->lock);
 

--- a/mm/kfence/report.c
+++ b/mm/kfence/report.c
@@ -38,18 +38,18 @@ static int get_stack_skipnr(const unsigned long stack_entries[], int num_entries
 		case KFENCE_ERROR_UAF:
 		case KFENCE_ERROR_OOB:
 		case KFENCE_ERROR_INVALID:
+			/* TODO: this name is x86-specific. Do we have to move
+			 * this name to <asm/kfence.h>? */
 			if (strnstr(buf, "asm_exc_page_fault", len))
 				goto found;
 			break;
 		case KFENCE_ERROR_CORRUPTION:
 		case KFENCE_ERROR_INVALID_FREE:
-			if (!strncmp(buf, "kfence_", sizeof("kfence_") - 1) ||
-			    !strncmp(buf, "__kfence_", sizeof("__kfence_") - 1))
+			if (str_has_prefix(buf, "kfence_") || str_has_prefix(buf, "__kfence_"))
 				fallback = skipnr + 1; /* In case kfree tail calls into kfence. */
 
 			/* Also the *_bulk() variants by only checking prefixes. */
-			if (!strncmp(buf, "kfree", sizeof("kfree") - 1) ||
-			    !strncmp(buf, "kmem_cache_free", sizeof("kmem_cache_free") - 1))
+			if (str_has_prefix(buf, "kfree") || str_has_prefix(buf, "kmem_cache_free"))
 				goto found;
 			break;
 		}


### PR DESCRIPTION
Test was unhappy after rebase. Seems something caused compiler to optimize more.

Signed-off-by: Marco Elver <elver@google.com>