### PR TITLE
kfence, Documentation: Include API for rendering documentation

### DIFF
--- a/Documentation/dev-tools/kfence.rst
+++ b/Documentation/dev-tools/kfence.rst
@@ -44,6 +44,19 @@ Implementation Details
 
 TODO
 
+Interface
+---------
+
+The following describes the functions which are used by allocators as well page
+handling code to set up and deal with KFENCE allocations.
+
+.. kernel-doc:: include/linux/kfence.h
+   :functions: is_kfence_address
+               kfence_shutdown_cache
+               kfence_alloc kfence_free
+               kfence_ksize kfence_object_start
+               kfence_handle_page_fault
+
 Related Tools
 -------------
 


### PR DESCRIPTION
This is so that we can test the API documentation with 'make htmldocs'.