### PR TITLE
Support ARM64

### DIFF
--- a/arch/arm64/Kconfig
+++ b/arch/arm64/Kconfig
@@ -131,6 +131,7 @@ config ARM64
 	select HAVE_ARCH_JUMP_LABEL_RELATIVE
 	select HAVE_ARCH_KASAN if !(ARM64_16K_PAGES && ARM64_VA_BITS_48)
 	select HAVE_ARCH_KASAN_SW_TAGS if HAVE_ARCH_KASAN
+	select HAVE_ARCH_KFENCE if (!ARM64_16K_PAGES && !ARM64_64K_PAGES)
 	select HAVE_ARCH_KGDB
 	select HAVE_ARCH_MMAP_RND_BITS
 	select HAVE_ARCH_MMAP_RND_COMPAT_BITS if COMPAT
@@ -332,6 +333,10 @@ config KASAN_SHADOW_OFFSET
 	default 0xefffffc800000000 if ARM64_VA_BITS_39 && KASAN_SW_TAGS
 	default 0xeffffff900000000 if ARM64_VA_BITS_36 && KASAN_SW_TAGS
 	default 0xffffffffffffffff
+
+config KFENCE_STATIC_POOL
+	def_bool n
+	depends on KFENCE
 
 source "arch/arm64/Kconfig.platforms"
 

--- a/arch/arm64/Kconfig
+++ b/arch/arm64/Kconfig
@@ -334,6 +334,7 @@ config KASAN_SHADOW_OFFSET
 	default 0xeffffff900000000 if ARM64_VA_BITS_36 && KASAN_SW_TAGS
 	default 0xffffffffffffffff
 
+# TODO: Figure out how to use a static pool on ARM64!
 config KFENCE_STATIC_POOL
 	def_bool n
 	depends on KFENCE

--- a/arch/arm64/Kconfig
+++ b/arch/arm64/Kconfig
@@ -334,11 +334,6 @@ config KASAN_SHADOW_OFFSET
 	default 0xeffffff900000000 if ARM64_VA_BITS_36 && KASAN_SW_TAGS
 	default 0xffffffffffffffff
 
-# TODO: Figure out how to use a static pool on ARM64!
-config KFENCE_STATIC_POOL
-	def_bool n
-	depends on KFENCE
-
 source "arch/arm64/Kconfig.platforms"
 
 menu "Kernel Features"

--- a/arch/arm64/include/asm/kfence.h
+++ b/arch/arm64/include/asm/kfence.h
@@ -9,7 +9,6 @@
 
 #include <asm/cacheflush.h>
 
-#define KFENCE_POOL_ALIGNMENT PAGE_SIZE
 #define KFENCE_SKIP_ARCH_FAULT_HANDLER "el1_sync"
 
 /*

--- a/arch/arm64/include/asm/kfence.h
+++ b/arch/arm64/include/asm/kfence.h
@@ -12,6 +12,12 @@
 #define KFENCE_POOL_ALIGNMENT PAGE_SIZE
 #define KFENCE_SKIP_ARCH_FAULT_HANDLER "el1_sync"
 
+/*
+ * TODO: Figure out how to use the static pool on ARM64! If we do not manage to
+ * do this before the RFC, turn it into a FIXME here instead, to indicate this
+ * may require improvement, and solicit feedback on it.
+ */
+
 static inline bool arch_kfence_initialize_pool(void)
 {
 	const unsigned int num_pages = ilog2(roundup_pow_of_two(KFENCE_POOL_SIZE / PAGE_SIZE));

--- a/arch/arm64/include/asm/kfence.h
+++ b/arch/arm64/include/asm/kfence.h
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#ifndef __ASM_KFENCE_H
+#define __ASM_KFENCE_H
+
+#include <linux/kfence.h>
+#include <linux/log2.h>
+#include <linux/mm.h>
+
+#include <asm/cacheflush.h>
+
+#define KFENCE_POOL_ALIGNMENT PAGE_SIZE
+#define KFENCE_SKIP_ARCH_FAULT_HANDLER "el1_sync"
+
+static inline bool arch_kfence_initialize_pool(void)
+{
+	const unsigned int num_pages = ilog2(roundup_pow_of_two(KFENCE_POOL_SIZE / PAGE_SIZE));
+	struct page *pages = alloc_pages(GFP_KERNEL, num_pages);
+
+	if (!pages)
+		return false;
+
+	__kfence_pool = page_address(pages);
+	return true;
+}
+
+static inline bool kfence_protect_page(unsigned long addr, bool protect)
+{
+	set_memory_valid(addr, 1, !protect);
+
+	return true;
+}
+
+#endif /* __ASM_KFENCE_H */

--- a/arch/arm64/mm/fault.c
+++ b/arch/arm64/mm/fault.c
@@ -10,6 +10,7 @@
 #include <linux/acpi.h>
 #include <linux/bitfield.h>
 #include <linux/extable.h>
+#include <linux/kfence.h>
 #include <linux/signal.h>
 #include <linux/mm.h>
 #include <linux/hardirq.h>
@@ -308,6 +309,9 @@ static void __do_kernel_fault(unsigned long addr, unsigned int esr,
 
 	if (WARN_RATELIMIT(is_spurious_el1_translation_fault(addr, esr, regs),
 	    "Ignoring spurious kernel translation fault at virtual address %016lx\n", addr))
+		return;
+
+	if (kfence_handle_page_fault(addr))
 		return;
 
 	if (is_el1_permission_fault(addr, esr, regs)) {

--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -333,6 +333,10 @@ config KASAN_SHADOW_OFFSET
 	depends on KASAN
 	default 0xdffffc0000000000
 
+config KFENCE_STATIC_POOL
+	def_bool y
+	depends on KFENCE
+
 config HAVE_INTEL_TXT
 	def_bool y
 	depends on INTEL_IOMMU && ACPI

--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -144,6 +144,7 @@ config X86
 	select HAVE_ARCH_KASAN			if X86_64
 	select HAVE_ARCH_KASAN_VMALLOC		if X86_64
 	select HAVE_ARCH_KFENCE
+	select HAVE_ARCH_KFENCE_STATIC_POOL
 	select HAVE_ARCH_KGDB
 	select HAVE_ARCH_MMAP_RND_BITS		if MMU
 	select HAVE_ARCH_MMAP_RND_COMPAT_BITS	if MMU && COMPAT
@@ -332,10 +333,6 @@ config KASAN_SHADOW_OFFSET
 	hex
 	depends on KASAN
 	default 0xdffffc0000000000
-
-config KFENCE_STATIC_POOL
-	def_bool y
-	depends on KFENCE
 
 config HAVE_INTEL_TXT
 	def_bool y

--- a/include/linux/kfence.h
+++ b/include/linux/kfence.h
@@ -16,7 +16,11 @@
  * extended guard page, but otherwise has no special purpose.
  */
 #define KFENCE_POOL_SIZE ((CONFIG_KFENCE_NUM_OBJECTS + 1) * 2 * PAGE_SIZE)
+#ifdef CONFIG_KFENCE_STATIC_POOL
 extern char __kfence_pool[KFENCE_POOL_SIZE];
+#else
+extern char *__kfence_pool;
+#endif
 
 extern struct static_key_false kfence_allocation_key;
 

--- a/include/linux/kfence.h
+++ b/include/linux/kfence.h
@@ -16,7 +16,7 @@
  * extended guard page, but otherwise has no special purpose.
  */
 #define KFENCE_POOL_SIZE ((CONFIG_KFENCE_NUM_OBJECTS + 1) * 2 * PAGE_SIZE)
-#ifdef CONFIG_KFENCE_STATIC_POOL
+#ifdef CONFIG_HAVE_ARCH_KFENCE_STATIC_POOL
 extern char __kfence_pool[KFENCE_POOL_SIZE];
 #else
 extern char *__kfence_pool;

--- a/include/linux/kfence.h
+++ b/include/linux/kfence.h
@@ -8,8 +8,6 @@
 #include <linux/static_key.h>
 #include <linux/types.h>
 
-struct kmem_cache;
-
 #ifdef CONFIG_KFENCE
 
 /*

--- a/lib/Kconfig.kfence
+++ b/lib/Kconfig.kfence
@@ -1,6 +1,11 @@
 config HAVE_ARCH_KFENCE
 	bool
 
+config HAVE_ARCH_KFENCE_STATIC_POOL
+	bool
+	help
+	  If the architecture supports using the static pool.
+
 menuconfig KFENCE
 	bool "KFENCE: low-overhead use-after-free and buffer-overflow detector"
 	depends on HAVE_ARCH_KFENCE && (!KASAN || EXPERT) && (SLAB || SLUB)

--- a/mm/kfence/core.c
+++ b/mm/kfence/core.c
@@ -50,12 +50,17 @@ module_param_named(sample_interval, kfence_sample_interval, ulong,
 static bool kfence_enabled __read_mostly;
 
 /*
- * The pool of pages used for guard pages and objects. Allocated statically, so
- * that is_kfence_address() avoids a pointer load, and simply compares against a
- * constant address. Assume that if KFENCE is compiled into the kernel, it is
- * usually enabled, and the space is to be allocated one way or another.
+ * The pool of pages used for guard pages and objects. If supported, allocated
+ * statically, so that is_kfence_address() avoids a pointer load, and simply
+ * compares against a constant address. Assume that if KFENCE is compiled into
+ * the kernel, it is usually enabled, and the space is to be allocated one way
+ * or another.
  */
+#ifdef CONFIG_KFENCE_STATIC_POOL
 char __kfence_pool[KFENCE_POOL_SIZE] __aligned(KFENCE_POOL_ALIGNMENT);
+#else
+char *__kfence_pool __read_mostly;
+#endif
 EXPORT_SYMBOL(__kfence_pool); /* Export for test modules. */
 
 /*
@@ -380,12 +385,15 @@ static void rcu_guarded_free(struct rcu_head *h)
 
 static bool __init kfence_initialize_pool(void)
 {
-	unsigned long addr = (unsigned long)__kfence_pool;
-	struct page *pages = virt_to_page(addr);
+	unsigned long addr;
+	struct page *pages;
 	int i;
 
-	if (!unlikely(arch_kfence_initialize_pool()))
+	if (!arch_kfence_initialize_pool())
 		return false;
+
+	addr = (unsigned long)__kfence_pool;
+	pages = virt_to_page(addr);
 
 	/*
 	 * Set up non-redzone pages: they must have PG_slab set, to avoid
@@ -395,7 +403,7 @@ static bool __init kfence_initialize_pool(void)
 	 * fast-path in SLUB, and therefore need to ensure kfree() correctly
 	 * enters __slab_free() slow-path.
 	 */
-	for (i = 0; i < sizeof(__kfence_pool) / PAGE_SIZE; i++) {
+	for (i = 0; i < KFENCE_POOL_SIZE / PAGE_SIZE; i++) {
 		if (!i || (i % 2))
 			continue;
 
@@ -560,7 +568,7 @@ void __init kfence_init(void)
 
 	schedule_delayed_work(&kfence_timer, 0);
 	WRITE_ONCE(kfence_enabled, true);
-	pr_info("initialized - using %zu bytes for %d objects", ARRAY_SIZE(__kfence_pool),
+	pr_info("initialized - using %zu bytes for %d objects", KFENCE_POOL_SIZE,
 		CONFIG_KFENCE_NUM_OBJECTS);
 	if (IS_ENABLED(CONFIG_DEBUG_KERNEL))
 		pr_cont(" at 0x%px-0x%px\n", (void *)__kfence_pool,

--- a/mm/kfence/core.c
+++ b/mm/kfence/core.c
@@ -56,7 +56,7 @@ static bool kfence_enabled __read_mostly;
  * the kernel, it is usually enabled, and the space is to be allocated one way
  * or another.
  */
-#ifdef CONFIG_KFENCE_STATIC_POOL
+#ifdef CONFIG_HAVE_ARCH_KFENCE_STATIC_POOL
 char __kfence_pool[KFENCE_POOL_SIZE] __aligned(KFENCE_POOL_ALIGNMENT);
 #else
 char *__kfence_pool __read_mostly;

--- a/mm/kfence/report.c
+++ b/mm/kfence/report.c
@@ -41,7 +41,7 @@ static int get_stack_skipnr(const unsigned long stack_entries[], int num_entries
 		case KFENCE_ERROR_UAF:
 		case KFENCE_ERROR_OOB:
 		case KFENCE_ERROR_INVALID:
-			if (strnstr(buf, KFENCE_SKIP_ARCH_FAULT_HANDLER, len))
+			if (!strncmp(buf, KFENCE_SKIP_ARCH_FAULT_HANDLER, len))
 				goto found;
 			break;
 		case KFENCE_ERROR_CORRUPTION:


### PR DESCRIPTION
Add support for ARM64.

It appears that the static pool cannot be used on ARM64 trivially, because it doesn't set up valid pages for statically allocated memory (at least `virt_to_page()` always returned an invalid page pointer). At some future point, we may want to try and understand if we can force it to give us some pages.

I will try to research more what exactly happens with .bss memory on ARM64 for the commit message. If you know what's happening, please let me know.

All tests pass in a VM (except the test_gfpzero is a bit flaky due to it not getting the same object back)!

(I'll wait to push this until your API documentation changes are in the repo, after which I'll do a rebase, as there are some conflicts.)