### PR TITLE
kfence: Address TODOs, and turn the ARM64 TODO into a FIXME

### DIFF
--- a/arch/arm64/include/asm/kfence.h
+++ b/arch/arm64/include/asm/kfence.h
@@ -12,9 +12,9 @@
 #define KFENCE_SKIP_ARCH_FAULT_HANDLER "el1_sync"
 
 /*
- * TODO: Figure out how to use the static pool on ARM64! If we do not manage to
- * do this before the RFC, turn it into a FIXME here instead, to indicate this
- * may require improvement, and solicit feedback on it.
+ * FIXME: Support HAVE_ARCH_KFENCE_STATIC_POOL: Use the statically allocated
+ * __kfence_pool, to avoid the extra pointer load for is_kfence_address(). By
+ * default, however, we do not have struct pages for static allocations.
  */
 
 static inline bool arch_kfence_initialize_pool(void)

--- a/mm/kfence/core.c
+++ b/mm/kfence/core.c
@@ -104,15 +104,6 @@ static_assert(ARRAY_SIZE(counter_names) == KFENCE_COUNTER_COUNT);
 
 /* === Internals ============================================================ */
 
-/*
- * TODO(elver): With the move of arch-specific code to asm, kfence core.c got a
- * lot simpler. Maybe we can move report.c code back here and remove the kfence/
- * dir? Although, currently the test wants something from kfence.h (but it can
- * be made standalone), and I'd hate to have more than 2 new files in mm/.
- * Looking at other files in mm/, I think we need to merge them if the final LOC
- * is ~1000 or less. :-/
- */
-
 static bool kfence_protect(unsigned long addr)
 {
 	return !KFENCE_WARN_ON(!kfence_protect_page(ALIGN_DOWN(addr, PAGE_SIZE), true));


### PR DESCRIPTION
As discussed, turn the ARM64 TODO into a FIXME, as it's optional to resolve before the RFC.

Also remove the TODO about merging the files, as it seems unnecessary for the RFC. If maintainers request consolidation, we'll happily merge them.

With that, we have only 1 non-formatting related TODO left in core.c. (And obviously the TODOs in Documentation, but no major TODOs left in code.)