### PR TITLE
kfence: fix kfence_debugfs_init() declaration, should be returning int

### DIFF
--- a/mm/kfence/core.c
+++ b/mm/kfence/core.c
@@ -503,12 +503,13 @@ static const struct file_operations objects_fops = {
 	.llseek = seq_lseek,
 };
 
-static void __init kfence_debugfs_init(void)
+static int __init kfence_debugfs_init(void)
 {
 	struct dentry *kfence_dir = debugfs_create_dir("kfence", NULL);
 
 	debugfs_create_file("stats", 0400, kfence_dir, NULL, &stats_fops);
 	debugfs_create_file("objects", 0400, kfence_dir, NULL, &objects_fops);
+	return 0;
 }
 
 late_initcall(kfence_debugfs_init);


### PR DESCRIPTION
Signed-off-by: Alexander Potapenko <glider@google.com>