### PR TITLE
kfence: Remove clang-format on/off

### DIFF
--- a/include/linux/kfence.h
+++ b/include/linux/kfence.h
@@ -160,9 +160,6 @@ bool __must_check kfence_handle_page_fault(unsigned long addr);
 
 #else /* CONFIG_KFENCE */
 
-// TODO: remove for v1
-// clang-format off
-
 static inline bool is_kfence_address(const void *addr) { return false; }
 static inline void kfence_init(void) { }
 static inline bool __must_check kfence_shutdown_cache(struct kmem_cache *s) { return true; }
@@ -171,9 +168,6 @@ static inline size_t kfence_ksize(const void *addr) { return 0; }
 static inline void *kfence_object_start(const void *addr) { return NULL; }
 static inline bool __must_check kfence_free(void *addr) { return false; }
 static inline bool __must_check kfence_handle_page_fault(unsigned long addr) { return false; }
-
-// TODO: remove for v1
-// clang-format on
 
 #endif
 

--- a/mm/kfence/core.c
+++ b/mm/kfence/core.c
@@ -22,7 +22,6 @@
 #include "kfence.h"
 
 /* Disables KFENCE on the first warning assuming an irrecoverable error. */
-// clang-format off
 #define KFENCE_WARN_ON(cond)                                                   \
 	({                                                                     \
 		const bool __cond = WARN_ON(cond);                             \
@@ -30,7 +29,6 @@
 			WRITE_ONCE(kfence_enabled, false);                     \
 		__cond;                                                        \
 	})
-// clang-format on
 
 #ifndef CONFIG_KFENCE_FAULT_INJECTION /* Only defined with CONFIG_EXPERT. */
 #define CONFIG_KFENCE_FAULT_INJECTION 0
@@ -92,14 +90,12 @@ enum kfence_counter_id {
 	KFENCE_COUNTER_COUNT,
 };
 static atomic_long_t counters[KFENCE_COUNTER_COUNT];
-// clang-format off
 static const char *const counter_names[] = {
 	[KFENCE_COUNTER_ALLOCATED]	= "currently allocated",
 	[KFENCE_COUNTER_ALLOCS]		= "total allocations",
 	[KFENCE_COUNTER_FREES]		= "total frees",
 	[KFENCE_COUNTER_BUGS]		= "total bugs",
 };
-// clang-format on
 static_assert(ARRAY_SIZE(counter_names) == KFENCE_COUNTER_COUNT);
 
 /* === Internals ============================================================ */

--- a/mm/kfence/kfence-test.c
+++ b/mm/kfence/kfence-test.c
@@ -677,12 +677,9 @@ static void test_memcache_alloc_bulk(struct kunit *test)
  * additional info in the name. Set up 2 tests per test case, one using the
  * default allocator, and another using a custom memcache (suffix '-memcache').
  */
-// clang-format off
-// TODO: fix formatting for v1
 #define KFENCE_KUNIT_CASE(test_name)						\
 	{ .run_case = test_name, .name = #test_name },				\
 	{ .run_case = test_name, .name = #test_name "-memcache" }
-// clang-format on
 
 static struct kunit_case kfence_test_cases[] = {
 	KFENCE_KUNIT_CASE(test_out_of_bounds_read),


### PR DESCRIPTION
This is to get the rebased patch-series ready. From this point on, we should probably use clang-format-diff.

I could probably just apply this to the kfence-rebase-wip branch, but it'll make cherry-picking onto + rebasing that branch more difficult.