### PR TITLE
kfence: kmemleak: use delete_object_part() for KFENCE pool

### DIFF
--- a/mm/kmemleak.c
+++ b/mm/kmemleak.c
@@ -1947,16 +1947,11 @@ void __init kmemleak_init(void)
 	/* register the data/bss sections */
 	create_object((unsigned long)_sdata, _edata - _sdata,
 		      KMEMLEAK_GREY, GFP_ATOMIC);
-#if defined(CONFIG_KFENCE) && defined(CONFIG_HAVE_ARCH_KFENCE_STATIC_POOL)
-	/* KFENCE objects are located in .bss, which may confuse kmemleak. Skip them. */
-	create_object((unsigned long)__bss_start, __kfence_pool - __bss_start,
-		      KMEMLEAK_GREY, GFP_ATOMIC);
-	create_object((unsigned long)__kfence_pool + KFENCE_POOL_SIZE,
-		      __bss_stop - (__kfence_pool + KFENCE_POOL_SIZE),
-		      KMEMLEAK_GREY, GFP_ATOMIC);
-#else
 	create_object((unsigned long)__bss_start, __bss_stop - __bss_start,
 		      KMEMLEAK_GREY, GFP_ATOMIC);
+#if defined(CONFIG_KFENCE) && defined(CONFIG_HAVE_ARCH_KFENCE_STATIC_POOL)
+	/* KFENCE objects are located in .bss, which may confuse kmemleak. Skip them. */
+	delete_object_part((unsigned long)__kfence_pool, KFENCE_POOL_SIZE);
 #endif
 
 	/* only register .data..ro_after_init if not within .data */


### PR DESCRIPTION
As suggested by Catalin Marinas

Signed-off-by: Alexander Potapenko <glider@google.com>