### PR TITLE
kfence: test: More closely follow new naming guidelines

### DIFF
--- a/lib/Kconfig.kfence
+++ b/lib/Kconfig.kfence
@@ -60,8 +60,9 @@ config KFENCE_FAULT_INJECTION
 	  this option is to stress-test KFENCE with concurrent error reports
 	  and allocations/frees. A value of 0 disables fault injection.
 
-config KFENCE_TEST
-	tristate "KFENCE test suite"
+config KFENCE_KUNIT_TEST
+	tristate "KFENCE integration test suite" if !KUNIT_ALL_TESTS
+	default KUNIT_ALL_TESTS
 	depends on TRACEPOINTS && KUNIT
 	help
 	  Test suite for KFENCE, testing various error detection scenarios with

--- a/mm/kfence/Makefile
+++ b/mm/kfence/Makefile
@@ -2,5 +2,5 @@
 
 obj-$(CONFIG_KFENCE) := core.o report.o
 
-CFLAGS_kfence-test.o := -g -fno-omit-frame-pointer -fno-optimize-sibling-calls
-obj-$(CONFIG_KFENCE_TEST) += kfence-test.o
+CFLAGS_kfence_test.o := -g -fno-omit-frame-pointer -fno-optimize-sibling-calls
+obj-$(CONFIG_KFENCE_KUNIT_TEST) += kfence_test.o

--- a/mm/kfence/kfence_test.c
+++ b/mm/kfence/kfence_test.c
@@ -728,7 +728,7 @@ static void test_exit(struct kunit *test)
 }
 
 static struct kunit_suite kfence_test_suite = {
-	.name = "kfence-test",
+	.name = "kfence",
 	.test_cases = kfence_test_cases,
 	.init = test_init,
 	.exit = test_exit,


### PR DESCRIPTION
While it's easy to change, let's switch to what appears to be the final
naming guidelines:

	https://lkml.kernel.org/r/20200909051631.2960347-1-davidgow@google.com

The major changes here are:

	s/kfence-test/kfence_test/
	s/KFENCE_TEST/KFENCE_KUNIT_TEST/

The config variable naming is already used by a bunch of tests in the
kernel. The filename change is a result of a longer discussion; the
change from '-' to ``_`` is motivated by the fact that the real module
name only contains ``_`` even if the filename contains '-'.