### PR TITLE
Minor fixes for v2

### DIFF
--- a/mm/kfence/core.c
+++ b/mm/kfence/core.c
@@ -42,8 +42,7 @@ static unsigned long kfence_sample_interval __read_mostly = CONFIG_KFENCE_SAMPLE
 #undef MODULE_PARAM_PREFIX
 #endif
 #define MODULE_PARAM_PREFIX "kfence."
-module_param_named(sample_interval, kfence_sample_interval, ulong,
-		   IS_ENABLED(CONFIG_DEBUG_KERNEL) ? 0600 : 0400);
+module_param_named(sample_interval, kfence_sample_interval, ulong, 0600);
 
 static bool kfence_enabled __read_mostly;
 


### PR DESCRIPTION
There were 2 smaller fixes in the other PR. Specifically the tweak to allow changing sample_interval for all builds at runtime, and calling prandom_u32() only if needed.

I am somewhat worried that changing sample_interval at runtime can be abused (e.g. by curious sysadmins), but I suppose if you're root, you already own the system anyway.

Thanks,
-- Marco