### PR TITLE
kfence: v3: Lower line buffer size

### DIFF
--- a/mm/kfence/kfence_test.c
+++ b/mm/kfence/kfence_test.c
@@ -28,7 +28,7 @@
 static struct {
 	spinlock_t lock;
 	int nlines;
-	char lines[2][512];
+	char lines[2][256];
 } observed = {
 	.lock = __SPIN_LOCK_UNLOCKED(observed.lock),
 };


### PR DESCRIPTION
To avoid warnings of using more than 1024 bytes stack usage.

In a test run with a WARN_ON(256 > len) no warnings were triggered for
the test, and 256 bytes should still be enough.