### PR TITLE
kfence: v5: Also guard kasan_unpoison_shadow

### DIFF
--- a/mm/kasan/common.c
+++ b/mm/kasan/common.c
@@ -142,6 +142,14 @@ void kasan_unpoison_shadow(const void *address, size_t size)
 	 */
 	address = reset_tag(address);
 
+	/*
+	 * We may be called from SL*B internals, such as ksize(): with a size
+	 * not a multiple of machine-word size, avoid poisoning the invalid
+	 * portion of the word for KFENCE memory.
+	 */
+	if (is_kfence_address(address))
+		return;
+
 	kasan_poison_shadow(address, size, tag);
 
 	if (size & KASAN_SHADOW_MASK) {


### PR DESCRIPTION
... as it may be called from SL*B internals, currently ksize().

Fixes https://github.com/google/kasan/issues/153