### PR TITLE
kfence: arm64: force page granularity for the linear map

### DIFF
--- a/arch/arm64/mm/mmu.c
+++ b/arch/arm64/mm/mmu.c
@@ -1438,7 +1438,12 @@ int arch_add_memory(int nid, u64 start, u64 size,
 {
 	int ret, flags = 0;
 
-	if (rodata_full || debug_pagealloc_enabled())
+	/*
+	 * KFENCE requires linear map to be mapped at page granularity, so that
+	 * it is possible to protect/unprotect single pages in the KFENCE pool.
+	 */
+	if (rodata_full || debug_pagealloc_enabled() ||
+	    IS_ENABLED(CONFIG_KFENCE))
 		flags = NO_BLOCK_MAPPINGS | NO_CONT_MAPPINGS;
 
 	__create_pgd_mapping(swapper_pg_dir, start, __phys_to_virt(start),


### PR DESCRIPTION
KFENCE requires that individual pages from its memory pool can be
individually marked as accessible/inaccessible, therefore we force
the entire linear map to be mapped at page granularity.
Doing so may result in extra memory allocated for page tables in the
case rodata=full is not set, but currently CONFIG_RODATA_FULL_DEFAULT_ENABLED
is the default, so the general case will not be affected by this change.

Suggested-by: Mark Rutland <mark.rutland@arm.com>
Signed-off-by: Alexander Potapenko <glider@google.com>