### PR TITLE
More fixes for v5

### DIFF
--- a/arch/x86/include/asm/kfence.h
+++ b/arch/x86/include/asm/kfence.h
@@ -46,7 +46,6 @@ static inline bool kfence_protect_page(unsigned long addr, bool protect)
 {
 	unsigned int level;
 	pte_t *pte = lookup_address(addr, &level);
-	struct page *page = virt_to_page(addr);
 
 	if (WARN_ON(!pte || level != PG_LEVEL_4K))
 		return false;
@@ -59,9 +58,9 @@ static inline bool kfence_protect_page(unsigned long addr, bool protect)
 	 */
 
 	if (protect)
-		set_direct_map_invalid_noflush(page);
+		set_pte(pte, __pte(pte_val(*pte) & ~_PAGE_PRESENT));
 	else
-		set_direct_map_default_noflush(page);
+		set_pte(pte, __pte(pte_val(*pte) | _PAGE_PRESENT));
 
 	/* Flush this CPU's TLB. */
 	flush_tlb_one_kernel(addr);

--- a/lib/Kconfig.kfence
+++ b/lib/Kconfig.kfence
@@ -37,9 +37,8 @@ config KFENCE_SAMPLE_INTERVAL
 	  setting "kfence.sample_interval" to a non-zero value enables KFENCE.
 
 config KFENCE_NUM_OBJECTS
-	int "Number of guarded objects available"
+	int "Number of guarded objects available" if !COMPILE_TEST
 	default 255
-	range 1 1023 # For most architectures max is: 2^(MAX_ORDER - 1) - 1
 	help
 	  The number of guarded objects available. For each KFENCE object, 2
 	  pages are required; with one containing the object and two adjacent

--- a/mm/kasan/generic.c
+++ b/mm/kasan/generic.c
@@ -21,6 +21,7 @@
 #include <linux/init.h>
 #include <linux/kasan.h>
 #include <linux/kernel.h>
+#include <linux/kfence.h>
 #include <linux/kmemleak.h>
 #include <linux/linkage.h>
 #include <linux/memblock.h>
@@ -332,7 +333,7 @@ void kasan_record_aux_stack(void *addr)
 	struct kasan_alloc_meta *alloc_info;
 	void *object;
 
-	if (!(page && PageSlab(page)))
+	if (is_kfence_address(addr) || !(page && PageSlab(page)))
 		return;
 
 	cache = page->slab_cache;

--- a/mm/kfence/core.c
+++ b/mm/kfence/core.c
@@ -399,6 +399,8 @@ bool __init kfence_alloc_pool(void)
 	if (__kfence_pool)
 		return true; /* Allocated in arch_kfence_initialize_pool(). */
 
+	BUILD_BUG_ON(get_order(KFENCE_POOL_SIZE) >= MAX_ORDER);
+
 	pages = alloc_pages(GFP_KERNEL, get_order(KFENCE_POOL_SIZE));
 	if (!pages)
 		return false;


### PR DESCRIPTION
- Changes to KFENCE_NUM_OBJECTS handling. FYI: Turns out actual max order is MAX_ORDER-1 (🤔). So in reality the max number of objects on e.g. x86 is only 511.

- New KASAN problems, because of using page_alloc.

- set_direct_map_{invalid,default}_noflush() does not work due to potential deadlock.